### PR TITLE
License checker

### DIFF
--- a/tools/license/README.md
+++ b/tools/license/README.md
@@ -1,0 +1,16 @@
+# Istio License Generation Guide
+## Usage
+Note: This tool requires https://github.com/benbalter/licensee for --summary and --match_detail to work.
+The --branch flag is only used in generating links to licenses in the appropriate branch in istio/cni.
+Licenses under manual_append have been manually copied and OK'd (usually because the package source only 
+contains a link). 
+#### Generate complete dump of every license, suitable for including in release build/binary image:
+      go run get_dep_licenses.go --branch release-1.0.1
+#### CSV format output with one package per line:
+      go run get_dep_licenses.go --summary --branch release-1.0.1
+#### Detailed info about how closely each license matches official text:
+      go run get_dep_licenses.go --match-detail --branch release-1.0.1
+#### Use a different branch from the current one. Will do git checkout to that branch and back to the current on completion. This can only be used from inside Istio repo:
+      go run get_dep_licenses.go --branch release-1.0.1 --checkout
+#### Check if all licenses are Google approved. Outputs lists of restricted, reciprocal, missing, and unknown status licenses.
+      go run get_dep_licenses.go --check

--- a/tools/license/get_dep_licenses.go
+++ b/tools/license/get_dep_licenses.go
@@ -121,19 +121,19 @@ var (
 	// knownUnknownLicenses are either missing or unknown to licensee, but were manually copied and /or reviewed
 	// and are considered ok, so the tool will not complain about these.
 	knownUnknownLicenses = map[string]bool{
-		"github.com/jmespath/go-jmespath":                                         true,
-		"github.com/alicebob/gopher-json":                                         true,
-		"istio.io/istio/vendor/github.com/dchest/siphash":                         true,
-		"istio.io/istio/vendor/github.com/signalfx/com_signalfx_metrics_protobuf": true,
+		"github.com/jmespath/go-jmespath":                                       true,
+		"github.com/alicebob/gopher-json":                                       true,
+		"istio.io/cni/vendor/github.com/dchest/siphash":                         true,
+		"istio.io/cni/vendor/github.com/signalfx/com_signalfx_metrics_protobuf": true,
 	}
 	// Ignore package paths that don't start with this.
 	mustStartWith = []string{
-		"istio.io/istio/vendor",
+		"istio.io/cni/vendor",
 		"vendor",
 	}
 	// After ignoring anything not in mustStartWith, further exclude anything with prefix below.
 	skipPrefixes = []string{
-		"istio.io/istio/vendor/github.com/gogo",
+		"istio.io/cni/vendor/github.com/gogo",
 		"vendor/golang_org",
 	}
 	// root is the root of Go src code.

--- a/tools/license/get_dep_licenses.go
+++ b/tools/license/get_dep_licenses.go
@@ -1,0 +1,549 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary get_dep_licenses outputs aggrerate license information for all transitive Istio dependencies.
+// This tool requires https://github.com/benbalter/licensee to work.
+// Usage:
+//   1) Generate complete dump of every license, suitable for including in release build/binary image:
+//      go run get_dep_licenses.go --branch release-1.0.1
+//   2) CSV format output with one package per line:
+//      go run get_dep_licenses.go --summary --branch release-1.0.1
+//   3) Detailed info about how closely each license matches official text:
+//      go run get_dep_licenses.go --match-detail --branch release-1.0.1
+//   4) Use a different branch from the current one. Will do git checkout to that branch and back to the current on completion.
+//      This can only be used from inside Istio repo:
+//      go run get_dep_licenses.go --branch release-1.0.1 --checkout
+//   5) Check if all licenses are Google approved. Outputs lists of restricted, reciprocal, missing, and unknown status licenses.
+//      go run get_dep_licenses.go --check
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	// maxLevelsToLicense is the maximum levels to go up to the root to find
+	// license in parent directories.
+	maxLevelsToLicense = 7
+)
+
+type licenseType int
+
+const (
+	// licenseTypeApproved is definitely ok to use and modify.
+	licenseTypeApproved licenseType = iota
+	// licenseTypeReciprocal can be used but not modified.
+	licenseTypeReciprocal
+	// licenseTypeRestricted
+	licenseTypeRestricted
+)
+
+var (
+	// licenseStrToType are code that's definitely ok to use and modify.
+	licenseStrToType = map[string]licenseType{
+		// licenseTypeApproved
+		"Apache-2.0":   licenseTypeApproved,
+		"ISC":          licenseTypeApproved,
+		"AFL-2.1":      licenseTypeApproved,
+		"AFL-3.0":      licenseTypeApproved,
+		"Artistic-1.0": licenseTypeApproved,
+		"Artistic-2.0": licenseTypeApproved,
+		"Apache-1.1":   licenseTypeApproved,
+		"BSD-1-Clause": licenseTypeApproved,
+		"BSD-2-Clause": licenseTypeApproved,
+		"BSD-3-Clause": licenseTypeApproved,
+		"FTL":          licenseTypeApproved,
+		"LPL-1.02":     licenseTypeApproved,
+		"MS-PL":        licenseTypeApproved,
+		"MIT":          licenseTypeApproved,
+		"NCSA":         licenseTypeApproved,
+		"OpenSSL":      licenseTypeApproved,
+		"PHP-3.0":      licenseTypeApproved,
+		"TCP-wrappers": licenseTypeApproved,
+		"W3C":          licenseTypeApproved,
+		"Xnet":         licenseTypeApproved,
+		"Zlib":         licenseTypeApproved,
+		// licenseTypeReciprocal
+		"CC0-1.0":  licenseTypeReciprocal,
+		"APSL-2.0": licenseTypeReciprocal,
+		"CDDL-1.0": licenseTypeReciprocal,
+		"CDDL-1.1": licenseTypeReciprocal,
+		"CPL-1.0":  licenseTypeReciprocal,
+		"EPL-1.0":  licenseTypeReciprocal,
+		"IPL-1.0":  licenseTypeReciprocal,
+		"MPL-1.0":  licenseTypeReciprocal,
+		"MPL-1.1":  licenseTypeReciprocal,
+		"MPL-2.0":  licenseTypeReciprocal,
+		"Ruby":     licenseTypeReciprocal,
+		// licenseTypeRestricted
+		"GPL-1.0-only":      licenseTypeRestricted,
+		"GPL-1.0-or-later":  licenseTypeRestricted,
+		"GPL-2.0-only":      licenseTypeRestricted,
+		"GPL-2.0-or-later":  licenseTypeRestricted,
+		"GPL-3.0-only":      licenseTypeRestricted,
+		"GPL-3.0-or-later":  licenseTypeRestricted,
+		"LGPL-2.0-only":     licenseTypeRestricted,
+		"LGPL-2.0-or-later": licenseTypeRestricted,
+		"LGPL-2.1-only":     licenseTypeRestricted,
+		"LGPL-2.1-or-later": licenseTypeRestricted,
+		"LGPL-3.0-only":     licenseTypeRestricted,
+		"LGPL-3.0-or-later": licenseTypeRestricted,
+		"NPL-1.0":           licenseTypeRestricted,
+		"NPL-1.1":           licenseTypeRestricted,
+		"OSL-1.0":           licenseTypeRestricted,
+		"OSL-1.1":           licenseTypeRestricted,
+		"OSL-2.0":           licenseTypeRestricted,
+		"OSL-2.1":           licenseTypeRestricted,
+		"OSL-3.0":           licenseTypeRestricted,
+		"QPL-1.0":           licenseTypeRestricted,
+		"Sleepycat":         licenseTypeRestricted,
+	}
+	// knownUnknownLicenses are either missing or unknown to licensee, but were manually copied and /or reviewed
+	// and are considered ok, so the tool will not complain about these.
+	knownUnknownLicenses = map[string]bool{
+		"github.com/jmespath/go-jmespath":                                         true,
+		"github.com/alicebob/gopher-json":                                         true,
+		"istio.io/istio/vendor/github.com/dchest/siphash":                         true,
+		"istio.io/istio/vendor/github.com/signalfx/com_signalfx_metrics_protobuf": true,
+	}
+	// Ignore package paths that don't start with this.
+	mustStartWith = []string{
+		"istio.io/istio/vendor",
+		"vendor",
+	}
+	// After ignoring anything not in mustStartWith, further exclude anything with prefix below.
+	skipPrefixes = []string{
+		"istio.io/istio/vendor/github.com/gogo",
+		"vendor/golang_org",
+	}
+	// root is the root of Go src code.
+	root = filepath.Join(os.Getenv("GOPATH"), "src")
+	// istioSubdir is the subdir from src root where istio source is found.
+	istioSubdir = "istio.io/cni"
+	// istioRoot is the path we expect to find istio source under.
+	istioRoot = filepath.Join(root, istioSubdir)
+	// istioReleaseBranch is the branch to generate licenses for.
+	istioReleaseBranch = ""
+)
+
+// LicenseInfo describes a license.
+type LicenseInfo struct {
+	packageName       string
+	path              string
+	url               string
+	licenseeOutput    string
+	licenseTypeString string
+	licenseText       string
+	exact             bool
+	confidence        string
+}
+
+// LicenseInfos is a slice of LicenseInfo.
+type LicenseInfos []*LicenseInfo
+
+// Len implements the sort.Interface interface.
+func (s LicenseInfos) Len() int {
+	return len(s)
+}
+
+// Less implements the sort.Interface interface.
+func (s LicenseInfos) Less(i, j int) bool {
+	return s[i].packageName < s[j].packageName
+}
+
+// Swap implements the sort.Interface interface.
+func (s LicenseInfos) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func main() {
+	var summary, checkout, matchDetail, check bool
+	flag.BoolVar(&summary, "summary", false, "Generate a summary report.")
+	flag.BoolVar(&checkout, "checkout", false, "Checkout target branch, return to current branch on completion. Can only use from inside Istio git repo.")
+	flag.BoolVar(&matchDetail, "match_detail", false, "Show information about match closeness for inexact matches.")
+	flag.BoolVar(&check, "check", false, "Check licenses to see if they are Google approved. Exits with error if any unapproved licenses are found, "+
+		"but success does not imply all licenses are approved.")
+	flag.StringVar(&istioReleaseBranch, "branch", "", "Istio release branch to use.")
+	flag.Parse()
+
+	// Verify inputs.
+	if summary && matchDetail {
+		log.Fatal("--summary and --match_detail cannot both be set.")
+	}
+
+	if istioReleaseBranch == "" && !check {
+		log.Fatal("--branch must be set.")
+	}
+
+	// Everything happens from istio root.
+	if err := os.Chdir(istioRoot); err != nil {
+		log.Fatalf("Could not chdir to Istio root at %s", istioRoot)
+	}
+
+	// Handle git checkouts if the release branch we want != current branch
+	var prevBranch string
+	if checkout {
+		// Save git branch to return to later.
+		pb, err := runBash("git", "rev-parse", "--abbrev-ref", "HEAD")
+		if err != nil {
+			log.Fatalf("Could not get current branch: %s", err)
+		}
+		prevBranch = strings.TrimSpace(string(pb))
+
+		// Need to switch to branch we're getting the licenses for.
+		_, err = runBash("git", "checkout", istioReleaseBranch)
+		if err != nil {
+			log.Fatalf("Could not git checkout %s: %s", istioReleaseBranch, err)
+		}
+	}
+	defer func() {
+		if checkout {
+			// Get back to original branch.
+
+			_, err := exec.Command("git", "checkout", prevBranch).Output()
+			if err != nil {
+				log.Fatalf("Could not git checkout back to original branch %s.", prevBranch)
+			}
+		}
+	}()
+
+	// List all the deps in vendor.
+	out, err := runBash("go", "list", "-f", `'{{ join .Deps  "\n"}}'`, "./vendor/...")
+	if err != nil {
+		log.Fatal(out)
+	}
+	outv := strings.Split(string(out), "\n")
+	outv, skipv := filter(dedup(outv))
+	sort.Strings(outv)
+	sort.Strings(skipv)
+	var missing []string
+
+	// TODO: detect multiple licenses.
+	licensePath := make(map[string]string, 0)
+	for _, p := range outv {
+		lf, err := findLicenseFile(p)
+		if err != nil || lf == nil {
+			if !knownUnknownLicenses[p] {
+				missing = append(missing, p)
+			}
+			continue
+		}
+		licensePath[p] = lf[0]
+	}
+
+	licenseTypes := make(map[string][]string, 0)
+	var reciprocalList, restrictedList, missingList []string
+	unknownMap := make(map[string]string, 0)
+	var licenses, exact, inexact LicenseInfos
+	for p, lp := range licensePath {
+		linfo := &LicenseInfo{}
+		if matchDetail || summary || check {
+			// This requires the external licensee program.
+			linfo, err = getLicenseeInfo(lp)
+			if err != nil {
+				log.Printf("licensee error: %s", err)
+				continue
+			}
+		}
+		linfo.packageName = strings.TrimPrefix(p, istioSubdir+"/vendor/")
+		linfo.licenseText = readFile(lp)
+		linfo.path = lp
+		linfo.url = pathToURL(lp)
+		licenses = append(licenses, linfo)
+		ltypeStr := linfo.licenseTypeString
+		if linfo.exact {
+			licenseTypes[ltypeStr] = append(licenseTypes[ltypeStr], p)
+			exact = append(exact, linfo)
+		} else {
+			inexact = append(inexact, linfo)
+		}
+
+		fmt.Printf("Checking %s\n", linfo.packageName)
+		lt, ok := licenseStrToType[ltypeStr]
+		switch {
+		// No license was found by licensee.
+		case ltypeStr == "":
+			missingList = append(missingList, linfo.packageName)
+		// License was found but not in a definite category.
+		case !ok:
+			if !knownUnknownLicenses[linfo.packageName] {
+				unknownMap[linfo.packageName] = ltypeStr
+			}
+		case lt == licenseTypeApproved:
+		case lt == licenseTypeReciprocal:
+			reciprocalList = append(reciprocalList, linfo.packageName)
+		case lt == licenseTypeRestricted:
+			restrictedList = append(restrictedList, linfo.packageName)
+		}
+	}
+
+	if check {
+		if len(reciprocalList) > 0 {
+			fmt.Println("===========================================================")
+			fmt.Println("The following packages have reciprocal licenses (code may")
+			fmt.Println("be used but not modified):")
+			fmt.Println("===========================================================")
+			fmt.Println(strings.Join(reciprocalList, "\n"))
+		}
+		if len(missingList) > 0 {
+			fmt.Println("===========================================================")
+			fmt.Println("The following packages have missing licenses:")
+			fmt.Println("===========================================================")
+			fmt.Println(strings.Join(missingList, "\n"))
+		}
+		if len(unknownMap) > 0 {
+			fmt.Println("===========================================================")
+			fmt.Println("The following packages have unknown status licenses (legal")
+			fmt.Println("review required). ")
+			fmt.Println("===========================================================")
+			for k, v := range unknownMap {
+				fmt.Printf("%s:%s\n", k, v)
+			}
+		}
+		if len(restrictedList) > 0 {
+			fmt.Println("===========================================================")
+			fmt.Println("The following packages had RESTRICTED licenses!")
+			fmt.Println("Packages MUST BE REMOVED! ")
+			fmt.Println("===========================================================")
+			fmt.Println(strings.Join(restrictedList, "\n"))
+			os.Exit(1)
+		}
+		return
+	}
+
+	sort.Sort(licenses)
+	sort.Sort(exact)
+	sort.Sort(inexact)
+
+	if summary {
+		for _, p := range missing {
+			fmt.Printf("%s, MISSING\n", p)
+		}
+		for _, l := range append(inexact, exact...) {
+			fmt.Printf("%s,%s,%s,%s\n", l.packageName, l.url, l.licenseTypeString, l.confidence)
+		}
+		return
+	}
+
+	if len(missing) > 0 {
+		fmt.Fprintln(os.Stderr, "===========================================================")
+		fmt.Fprintln(os.Stderr, "The following packages were missing license files.")
+		fmt.Fprintln(os.Stderr, "===========================================================")
+		for _, p := range missing {
+			fmt.Fprintln(os.Stderr, p)
+		}
+	}
+
+	if matchDetail {
+		fmt.Println("\n\n")
+		fmt.Println("===========================================================")
+		fmt.Println("The following packages had inexact licenses:")
+		fmt.Println("===========================================================")
+		for _, l := range inexact {
+			fmt.Printf("Package: %s\n", l.packageName)
+			fmt.Printf("URL: %s\n", l.url)
+			fmt.Printf("Match info:\n%s\n", l.licenseeOutput)
+			fmt.Printf("License text:\n%s\n", l.licenseText)
+			fmt.Println("-----------------------------------------------------------")
+		}
+
+		fmt.Println("\n\n")
+		fmt.Println("===========================================================")
+		fmt.Println("The following packages had exact licenses:")
+		fmt.Println("===========================================================")
+		for t, ps := range licenseTypes {
+			fmt.Printf("\nLicense type: %s\n", t)
+			sort.Strings(ps)
+			for _, p := range ps {
+				fmt.Printf("  %s\n", p)
+			}
+		}
+	} else {
+		fmt.Println("===========================================================")
+		fmt.Println("Package licenses")
+		fmt.Println("===========================================================")
+
+		for _, l := range append(exact, inexact...) {
+			fmt.Printf("Package: %s\n", l.packageName)
+			fmt.Printf("License URL: %s\n", l.url)
+			fmt.Printf("License text:\n%s\n", l.licenseText)
+			fmt.Println("-----------------------------------------------------------")
+		}
+
+		// Append manually added files.
+		manualAppendDir := filepath.Join(istioRoot, "tools/license/manual_append")
+		fs, err := ioutil.ReadDir(manualAppendDir)
+		if err != nil {
+			log.Fatalf("ReadDir: %s\n", err)
+		}
+		for _, f := range fs {
+			b, err := ioutil.ReadFile(filepath.Join(manualAppendDir, f.Name()))
+			if err != nil {
+				log.Fatalf("ReadFile (%s): %s\n", f.Name(), err)
+			}
+			fmt.Print(string(b))
+		}
+
+	}
+}
+
+// runBash runs a bash command. If command is successful, returns output, otherwise returns stderr output as error.
+func runBash(args ...string) (string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf(fmt.Sprint(err) + ": " + stderr.String())
+	}
+	return out.String(), nil
+}
+
+// pathToURL returns a URL to a path within Istio github code.
+func pathToURL(path string) string {
+	return strings.Replace(path, istioRoot, "https://github.com/istio/cni/blob/"+istioReleaseBranch, 1)
+}
+
+func readFile(path string) string {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err.Error()
+	}
+	return string(b)
+}
+
+func getLicenseeInfo(path string) (*LicenseInfo, error) {
+	outb, err := exec.Command("licensee", "detect", path).Output()
+	if err != nil {
+		return nil, err
+	}
+	out := string(outb)
+
+	licenseTypeString := getMatchingValue(out, "License:")
+	confidence := getMatchingValue(out, "  Confidence:")
+	if licenseTypeString == "NOASSERTION" {
+		licenseTypeString, confidence = getLicenseAndConfidence(out)
+	}
+
+	return &LicenseInfo{
+		licenseeOutput:    out,
+		licenseTypeString: licenseTypeString,
+		confidence:        confidence,
+		exact:             strings.Contains(out, "Licensee::Matchers::Exact"),
+	}, nil
+}
+
+func getMatchingValue(in, match string) string {
+	for _, l := range strings.Split(in, "\n") {
+		if strings.Contains(l, match) {
+			return strings.TrimSpace(strings.TrimPrefix(l, match))
+		}
+	}
+	return ""
+}
+
+// For NOASSERTION license type, it means we are below the match threshold. Still grab the closest match and output
+// confidence value.
+func getLicenseAndConfidence(in string) (string, string) {
+	for _, l := range strings.Split(in, "\n") {
+		if strings.Contains(l, " similarity:") {
+			fs := strings.Fields(l)
+			return fs[0], fs[2]
+		}
+	}
+	return "UNKNOWN", ""
+}
+
+func findLicenseFile(path string) ([]string, error) {
+	path = filepath.Join(root, path)
+	for i := 0; i <= maxLevelsToLicense; i++ {
+		outb, err := exec.Command("find", path, "-maxdepth", "1",
+			"-iname", "licen[sc]e*", "-o", "-iname", "copying").Output()
+		if err != nil {
+			return nil, err
+		}
+		out := string(outb)
+		if strings.TrimSpace(out) != "" {
+			return strings.Split(out, "\n"), nil
+		}
+		path = filepath.Join(path, "..")
+		if strings.Count(path, "/") < strings.Count(istioRoot, "/")+2 {
+			// go no further than the root of the package
+			break
+		}
+	}
+	return nil, nil
+}
+
+func filter(in []string) (keep, skip []string) {
+	for _, s := range in {
+		s = cleanString(s)
+		//sv := strings.Split(s, "/")
+
+		if !hasAnyPrefix(s, mustStartWith) || hasAnyPrefix(s, skipPrefixes) {
+			skip = append(skip, s)
+			continue
+		}
+		keep = append(keep, s)
+	}
+	return keep, skip
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+
+	}
+	return false
+}
+
+func cleanString(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "'")
+	s = strings.TrimSuffix(s, "'")
+	return s
+}
+
+func dedup(s []string) []string {
+	return fromMap(toMap(s))
+}
+
+func toMap(ss []string) map[string]interface{} {
+	out := make(map[string]interface{})
+	for _, s := range ss {
+		out[s] = nil
+	}
+	return out
+}
+
+func fromMap(m map[string]interface{}) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tools/license/manual_append/signalfx.txt
+++ b/tools/license/manual_append/signalfx.txt
@@ -1,0 +1,8 @@
+Package: github.com/signalfx/com_signalfx_metrics_protobuf
+License URL: https://github.com/istio/istio/blob/release-1.0/vendor/github.com/signalfx/com_signalfx_metrics_protobuf
+License text:
+## License
+
+Apache Software License v2. Copyright © 2015-2017 SignalFx
+
+-----------------------------------------------------------

--- a/tools/license/manual_append/siphash.txt
+++ b/tools/license/manual_append/siphash.txt
@@ -1,0 +1,133 @@
+Package: github.com/dchest/siphash
+License URL: https://github.com/istio/istio/blob/release-1.0/vendor/github.com/dchest/siphash/README.md
+License text:
+## Public domain dedication
+
+Written by Dmitry Chestnykh and Damian Gryski.
+
+To the extent possible under law, the authors have dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+http://creativecommons.org/publicdomain/zero/1.0/
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+-----------------------------------------------------------


### PR DESCRIPTION
Add Istio's license checker modified for cni:

One license (a MIT + 3 clause BSD combo) needs some type of legal verification.  Not sure how that is done - perhaps ask the TOC mailing list:

```
sdake@falkor-07:~/go/src/istio.io/cni/tools/license$ go run get_dep_licenses.go --check
Checking k8s.io/client-go/kubernetes/typed/storage/v1
Checking k8s.io/client-go/discovery
Checking golang.org/x/net/http2
Checking github.com/golang/protobuf/protoc-gen-go/grpc
Checking k8s.io/client-go/scale/scheme/extensionsint
Checking k8s.io/client-go/tools/metrics
Checking k8s.io/client-go/plugin/pkg/client/auth/exec
Checking k8s.io/client-go/tools/reference
Checking k8s.io/apimachinery/pkg/util/validation
Checking k8s.io/client-go/informers/storage/v1beta1
Checking k8s.io/apimachinery/pkg/runtime/serializer/recognizer
Checking k8s.io/client-go/listers/storage/v1
Checking golang.org/x/text/feature/plural
Checking k8s.io/api/events/v1beta1
Checking k8s.io/client-go/informers/settings
Checking k8s.io/client-go/listers/apps/v1beta2
Checking github.com/googleapis/gnostic/printer
Checking k8s.io/client-go/informers/scheduling/v1alpha1
Checking github.com/googleapis/gnostic/plugins/gnostic-analyze/statistics
Checking github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v2.0/xkcd/xkcd
Checking github.com/prometheus/client_model/go
Checking k8s.io/apimachinery/pkg/apimachinery/registered
Checking k8s.io/client-go/kubernetes/typed/rbac/v1beta1
Checking k8s.io/client-go/tools/cache
Checking k8s.io/client-go/discovery/fake
Checking k8s.io/client-go/informers/storage/v1alpha1
Checking k8s.io/api/authentication/v1beta1
Checking k8s.io/apimachinery/pkg/util/diff
Checking k8s.io/client-go/kubernetes/typed/storage/v1beta1
Checking k8s.io/apimachinery/third_party/forked/golang/reflect
Checking k8s.io/client-go/listers/autoscaling/v2beta1
Checking k8s.io/apimachinery/pkg/apis/meta/fuzzer
Checking k8s.io/client-go/third_party/forked/golang/template
Checking golang.org/x/crypto/cast5
Checking golang.org/x/net/http/httpguts
Checking github.com/prometheus/procfs/internal/util
Checking k8s.io/api/admissionregistration/v1beta1
Checking k8s.io/client-go/kubernetes/typed/core/v1
Checking github.com/howeyc/gopass
Checking golang.org/x/net/ipv4
Checking golang.org/x/text/runes
Checking k8s.io/client-go/kubernetes/typed/rbac/v1
Checking k8s.io/client-go/tools/clientcmd
Checking golang.org/x/crypto/openpgp/s2k
Checking k8s.io/client-go/listers/rbac/v1alpha1
Checking k8s.io/client-go/tools/clientcmd/api/latest
Checking k8s.io/client-go/tools/record
Checking golang.org/x/text/secure/bidirule
Checking k8s.io/client-go/informers/events/v1beta1
Checking k8s.io/client-go/listers/storage/v1beta1
Checking github.com/containernetworking/cni/pkg/version
Checking github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/googleauth
Checking k8s.io/client-go/informers/policy
Checking k8s.io/client-go/plugin/pkg/client/auth/gcp
Checking k8s.io/client-go/rest
Checking k8s.io/client-go/listers/batch/v2alpha1
Checking k8s.io/api/core/v1
Checking github.com/googleapis/gnostic/discovery
Checking golang.org/x/net/http2/hpack
Checking golang.org/x/text/encoding/htmlindex
Checking golang.org/x/text/encoding/simplifiedchinese
Checking k8s.io/client-go/kubernetes/typed/rbac/v1alpha1
Checking k8s.io/client-go/scale
Checking github.com/modern-go/reflect2
Checking github.com/projectcalico/libcalico-go/lib/selector/tokenizer
Checking k8s.io/client-go/util/retry
Checking golang.org/x/net/internal/socket
Checking k8s.io/apimachinery/pkg/api/resource
Checking k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake
Checking k8s.io/client-go/kubernetes/typed/settings/v1alpha1
Checking golang.org/x/text/language
Checking k8s.io/client-go/informers/certificates
Checking k8s.io/client-go/kubernetes/typed/events/v1beta1
Checking golang.org/x/crypto/openpgp/errors
Checking k8s.io/client-go/kubernetes/typed/core/v1/fake
Checking k8s.io/client-go/plugin/pkg/client/auth/azure
Checking k8s.io/client-go/util/integer
Checking github.com/projectcalico/libcalico-go/lib/backend/k8s/resources
Checking golang.org/x/text/encoding/internal
Checking k8s.io/client-go/listers/admissionregistration/v1beta1
Checking github.com/googleapis/gnostic/jsonwriter
Checking github.com/projectcalico/libcalico-go/lib/backend/k8s
Checking golang.org/x/text/encoding
Checking k8s.io/client-go/listers/batch/v1beta1
Checking k8s.io/api/apps/v1beta2
Checking k8s.io/client-go/scale/scheme
Checking golang.org/x/text/encoding/korean
Checking golang.org/x/text/internal/format
Checking github.com/projectcalico/libcalico-go/lib/backend/etcd
Checking k8s.io/apimachinery/pkg/util/net
Checking github.com/projectcalico/libcalico-go/lib/backend/model
Checking golang.org/x/net/internal/timeseries
Checking golang.org/x/text/message/catalog
Checking k8s.io/client-go/informers/core/v1
Checking golang.org/x/net/context
Checking golang.org/x/text/cmd/gotext/examples/extract_http/pkg
Checking github.com/beorn7/perks/quantile
Checking github.com/googleapis/gnostic/OpenAPIv3
Checking golang.org/x/crypto/acme
Checking gopkg.in/yaml.v2
Checking github.com/googleapis/gnostic/jsonschema
Checking k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake
Checking k8s.io/apimachinery/pkg/selection
Checking k8s.io/client-go/informers/batch/v1
Checking k8s.io/api/admissionregistration/v1alpha1
Checking golang.org/x/crypto/internal/chacha20
Checking k8s.io/client-go/kubernetes/typed/authorization/v1/fake
Checking k8s.io/client-go/kubernetes/typed/batch/v1beta1
Checking github.com/projectcalico/libcalico-go/lib/api
Checking k8s.io/apimachinery/pkg/apis/testapigroup/v1
Checking k8s.io/apimachinery/pkg/util/json
Checking github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v2.0/sample/sample
Checking github.com/projectcalico/libcalico-go/lib/backend/extensions
Checking k8s.io/api/batch/v1
Checking k8s.io/client-go/transport/spdy
Checking k8s.io/client-go/tools/auth
Checking github.com/golang/glog
Checking golang.org/x/net/idna
Checking k8s.io/apimachinery/pkg/runtime/serializer/streaming
Checking k8s.io/apimachinery/pkg/apis/testapigroup
Checking k8s.io/apimachinery/pkg/fields
Checking github.com/matttproud/golang_protobuf_extensions/pbutil
Checking k8s.io/apimachinery/pkg/apimachinery/announced
Checking github.com/prometheus/common/promlog
Checking golang.org/x/text/width
Checking k8s.io/client-go/listers/certificates/v1beta1
Checking k8s.io/client-go/util/homedir
Checking github.com/projectcalico/libcalico-go/lib/selector
Checking github.com/prometheus/common/expfmt
Checking github.com/spf13/pflag
Checking golang.org/x/crypto/salsa20/salsa
Checking github.com/golang/protobuf/proto
Checking golang.org/x/text/unicode/norm
Checking k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake
Checking k8s.io/client-go/listers/rbac/v1
Checking golang.org/x/text/internal/cldrtree
Checking golang.org/x/text/internal/gen
Checking k8s.io/apimachinery/pkg/api/meta
Checking github.com/projectcalico/libcalico-go/lib/converter
Checking k8s.io/client-go/rest/watch
Checking github.com/prometheus/procfs/bcache
Checking golang.org/x/text/internal/catmsg
Checking k8s.io/api/networking/v1
Checking k8s.io/apimachinery/pkg/types
Checking k8s.io/client-go/informers/apps/v1
Checking k8s.io/client-go/informers/apps/v1beta2
Checking k8s.io/client-go/kubernetes/typed/authentication/v1
Checking k8s.io/client-go/listers/autoscaling/v1
Checking k8s.io/client-go/scale/scheme/appsv1beta1
Checking k8s.io/apimachinery/pkg/util/errors
Checking golang.org/x/crypto/nacl/secretbox
Checking golang.org/x/crypto/pkcs12/internal/rc2
Checking golang.org/x/time/rate
Checking k8s.io/apimachinery/pkg/runtime
Checking k8s.io/client-go/scale/scheme/extensionsv1beta1
Checking k8s.io/client-go/informers/rbac/v1alpha1
Checking k8s.io/apimachinery/pkg/version
Checking golang.org/x/text/internal
Checking k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake
Checking k8s.io/apimachinery/pkg/conversion
Checking k8s.io/apimachinery/pkg/util/sets
Checking k8s.io/client-go/kubernetes/typed/batch/v1/fake
Checking k8s.io/client-go/kubernetes/typed/policy/v1beta1
Checking golang.org/x/text/encoding/traditionalchinese
Checking golang.org/x/crypto/openpgp/elgamal
Checking k8s.io/client-go/pkg/apis/clientauthentication
Checking k8s.io/client-go/scale/scheme/autoscalingv1
Checking github.com/projectcalico/libcalico-go/lib/numorstring
Checking k8s.io/api/extensions/v1beta1
Checking golang.org/x/text/cases
Checking k8s.io/api/rbac/v1beta1
Checking k8s.io/apimachinery/pkg/conversion/queryparams
Checking k8s.io/client-go/informers/certificates/v1beta1
Checking k8s.io/client-go/util/jsonpath
Checking k8s.io/client-go/informers/networking/v1
Checking k8s.io/client-go/tools/clientcmd/api
Checking github.com/projectcalico/libcalico-go/lib/errors
Checking golang.org/x/net/context/ctxhttp
Checking k8s.io/client-go/kubernetes/typed/batch/v1
Checking github.com/golang/protobuf/proto/test_proto
Checking golang.org/x/text/message/pipeline
Checking k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
Checking github.com/projectcalico/libcalico-go/lib/api/unversioned
Checking golang.org/x/text/internal/tag
Checking k8s.io/api/settings/v1alpha1
Checking k8s.io/client-go/informers/events
Checking k8s.io/client-go/kubernetes/typed/apps/v1beta1
Checking github.com/imdario/mergo
Checking github.com/prometheus/procfs/xfs
Checking k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake
Checking github.com/googleapis/gnostic/compiler
Checking k8s.io/apimachinery/pkg/apis/meta/v1/validation
Checking k8s.io/apimachinery/pkg/apis/meta/v1beta1
Checking golang.org/x/text/collate
Checking k8s.io/api/authorization/v1beta1
Checking github.com/projectcalico/libcalico-go/lib/net
Checking golang.org/x/crypto/cryptobyte/asn1
Checking k8s.io/api/apps/v1beta1
Checking k8s.io/api/rbac/v1alpha1
Checking k8s.io/apimachinery/pkg/runtime/serializer/protobuf
Checking k8s.io/client-go/listers/admissionregistration/v1alpha1
Checking k8s.io/client-go/util/flowcontrol
Checking k8s.io/client-go/listers/policy/v1beta1
Checking k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
Checking github.com/golang/protobuf/conformance/internal/conformance_proto
Checking k8s.io/client-go/informers/scheduling
Checking github.com/prometheus/procfs/nfs
Checking golang.org/x/sys/cpu
Checking k8s.io/apimachinery/pkg/util/httpstream
Checking k8s.io/apimachinery/pkg/util/strategicpatch
Checking k8s.io/client-go/pkg/version
Checking github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v3.0/bookstore/bookstore
Checking k8s.io/apimachinery/pkg/apimachinery
Checking k8s.io/client-go/listers/apps/v1beta1
Checking github.com/projectcalico/libcalico-go/lib/backend
Checking k8s.io/apimachinery/pkg/runtime/serializer/json
Checking k8s.io/apimachinery/pkg/util/wait
Checking k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake
Checking golang.org/x/net/html
Checking golang.org/x/crypto/internal/subtle
Checking k8s.io/client-go/kubernetes/typed/authentication/v1beta1
Checking k8s.io/client-go/kubernetes/typed/rbac/v1/fake
Checking k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake
Checking github.com/golang/protobuf/protoc-gen-go/plugin
Checking github.com/golang/protobuf/ptypes/any
Checking github.com/projectcalico/libcalico-go/lib/backend/api
Checking golang.org/x/text/transform
Checking k8s.io/apimachinery/pkg/api/testing
Checking golang.org/x/crypto/openpgp/packet
Checking golang.org/x/crypto/ssh/terminal
Checking golang.org/x/net/internal/iana
Checking github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
Checking golang.org/x/text/encoding/charmap
Checking golang.org/x/text/internal/utf8internal
Checking k8s.io/api/storage/v1beta1
Checking k8s.io/client-go/informers/batch/v2alpha1
Checking k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1
Checking golang.org/x/crypto/ed25519
Checking k8s.io/apimachinery/pkg/util/duration
Checking k8s.io/client-go/informers/rbac/v1
Checking github.com/containernetworking/cni/libcni
Checking k8s.io/client-go/tools/pager
Checking k8s.io/client-go/plugin/pkg/client/auth/oidc
Checking k8s.io/client-go/tools/clientcmd/api/v1
Checking golang.org/x/text/encoding/internal/identifier
Checking k8s.io/client-go/informers/admissionregistration
Checking github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v2.0/bookstore/bookstore
Checking golang.org/x/crypto/pbkdf2
Checking k8s.io/api/scheduling/v1alpha1
Checking k8s.io/client-go/kubernetes/typed/storage/v1/fake
Checking github.com/containernetworking/cni/pkg/skel
Checking github.com/prometheus/client_golang/prometheus
Checking github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v3.0/urlshortener/urlshortener
Checking github.com/projectcalico/libcalico-go/lib/backend/compat
Checking k8s.io/client-go/kubernetes/typed/extensions/v1beta1
Checking golang.org/x/text/encoding/japanese
Checking k8s.io/client-go/listers/settings/v1alpha1
Checking k8s.io/client-go/plugin/pkg/client/auth
Checking golang.org/x/crypto/poly1305
Checking golang.org/x/net/html/atom
Checking k8s.io/client-go/scale/scheme/appsint
Checking golang.org/x/net/webdav/internal/xml
Checking golang.org/x/text/message
Checking github.com/googleapis/gnostic/extensions
Checking github.com/projectcalico/libcalico-go/lib/hwm
Checking k8s.io/apimachinery/pkg/util/intstr
Checking github.com/projectcalico/libcalico-go/lib/scope
Checking k8s.io/client-go/informers/autoscaling
Checking k8s.io/client-go/informers/rbac/v1beta1
Checking k8s.io/client-go/transport
Checking github.com/googleapis/gnostic/OpenAPIv2
Checking k8s.io/client-go/informers/apps/v1beta1
Checking k8s.io/client-go/informers/autoscaling/v2beta1
Checking k8s.io/client-go/kubernetes/scheme
Checking k8s.io/client-go/kubernetes/typed/authorization/v1
Checking k8s.io/api/autoscaling/v2beta1
Checking k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
Checking k8s.io/apimachinery/pkg/util/framer
Checking k8s.io/client-go/util/certificate/csr
Checking github.com/google/gofuzz
Checking k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake
Checking k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake
Checking k8s.io/client-go/informers/admissionregistration/v1beta1
Checking k8s.io/api/apps/v1
Checking k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake
Checking github.com/projectcalico/libcalico-go/lib/client
Checking k8s.io/client-go/informers/networking
Checking golang.org/x/text/internal/colltab
Checking k8s.io/apimachinery/pkg/runtime/serializer/versioning
Checking k8s.io/apimachinery/pkg/watch
Checking k8s.io/client-go/informers/extensions
Checking k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake
Checking k8s.io/client-go/kubernetes/typed/apps/v1/fake
Checking github.com/modern-go/concurrent
Checking golang.org/x/net/internal/nettest
Checking k8s.io/client-go/listers/scheduling/v1alpha1
Checking k8s.io/client-go/util/workqueue
Checking k8s.io/client-go/kubernetes/typed/batch/v2alpha1
Checking golang.org/x/crypto/blowfish
Checking k8s.io/client-go/kubernetes/typed/autoscaling/v1
Checking k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake
Checking k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake
Checking k8s.io/client-go/scale/scheme/appsv1beta2
Checking golang.org/x/net/internal/socks
Checking k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake
Checking k8s.io/client-go/tools/leaderelection/resourcelock
Checking github.com/containernetworking/cni/pkg/invoke
Checking github.com/projectcalico/libcalico-go/lib/ipip
Checking k8s.io/apimachinery/pkg/util/runtime
Checking k8s.io/client-go/kubernetes/typed/networking/v1/fake
Checking github.com/containernetworking/cni/pkg/types/020
Checking github.com/googleapis/gnostic/surface
Checking github.com/projectcalico/libcalico-go/lib/backend/k8s/custom
Checking golang.org/x/crypto/openpgp/armor
Checking golang.org/x/net/ipv6
Checking golang.org/x/text/unicode/bidi
Checking github.com/golang/protobuf/ptypes/duration
Checking k8s.io/client-go/listers/networking/v1
Checking k8s.io/client-go/util/buffer
Checking k8s.io/client-go/kubernetes/typed/networking/v1
Checking k8s.io/api/policy/v1beta1
Checking k8s.io/client-go/dynamic
Checking k8s.io/client-go/informers/internalinterfaces
Checking github.com/sirupsen/logrus
Checking golang.org/x/text/unicode/cldr
Checking k8s.io/api/autoscaling/v1
Checking k8s.io/apimachinery/pkg/util/remotecommand
Checking github.com/containernetworking/cni/pkg/types/current
Checking k8s.io/client-go/testing
Checking k8s.io/client-go/util/cert
Checking github.com/projectcalico/libcalico-go/lib/hash
Checking k8s.io/apimachinery/pkg/apis/meta/internalversion
Checking k8s.io/client-go/informers/batch
Checking k8s.io/client-go/listers/apps/v1
Checking k8s.io/client-go/plugin/pkg/client/auth/openstack
Checking github.com/ghodss/yaml
Checking github.com/golang/protobuf/ptypes/struct
Checking k8s.io/apimachinery/pkg/util/validation/field
Checking k8s.io/client-go/informers/batch/v1beta1
Checking k8s.io/client-go/informers/core
Checking golang.org/x/text/internal/stringset
Checking k8s.io/client-go/kubernetes/typed/apps/v1beta2
Checking k8s.io/client-go/kubernetes/typed/storage/v1alpha1
Checking github.com/golang/protobuf/ptypes/wrappers
Checking k8s.io/client-go/informers/extensions/v1beta1
Checking k8s.io/api/storage/v1alpha1
Checking k8s.io/client-go/kubernetes
Checking k8s.io/client-go/kubernetes/typed/authentication/v1/fake
Checking k8s.io/client-go/tools/bootstrap/token/api
Checking k8s.io/apimachinery/pkg/util/mergepatch
Checking k8s.io/apimachinery/pkg/api/equality
Checking k8s.io/client-go/listers/rbac/v1beta1
Checking golang.org/x/crypto/ssh
Checking k8s.io/api/authorization/v1
Checking k8s.io/apimachinery/pkg/runtime/schema
Checking k8s.io/apimachinery/pkg/runtime/serializer
Checking k8s.io/client-go/informers/settings/v1alpha1
Checking golang.org/x/text/encoding/unicode
Checking k8s.io/client-go/kubernetes/typed/certificates/v1beta1
Checking github.com/googleapis/gnostic/plugins
Checking k8s.io/api/certificates/v1beta1
Checking github.com/containernetworking/cni/pkg/types
Checking github.com/golang/protobuf/ptypes
Checking k8s.io/client-go/listers/core/v1
Checking k8s.io/client-go/informers/storage
Checking k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake
Checking k8s.io/client-go/kubernetes/typed/apps/v1
Checking golang.org/x/sys/unix
Checking k8s.io/api/batch/v1beta1
Checking k8s.io/client-go/kubernetes/typed/authorization/v1beta1
Checking k8s.io/api/rbac/v1
Checking golang.org/x/crypto/curve25519
Checking k8s.io/apimachinery/pkg/util/cache
Checking github.com/projectcalico/libcalico-go/lib/selector/parser
Checking github.com/prometheus/common/model
Checking k8s.io/client-go/informers/storage/v1
Checking k8s.io/apimachinery/third_party/forked/golang/netutil
Checking k8s.io/client-go/informers/admissionregistration/v1alpha1
Checking k8s.io/client-go/informers/autoscaling/v1
Checking k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake
Checking github.com/json-iterator/go
Checking k8s.io/apimachinery/pkg/util/clock
Checking k8s.io/apimachinery/pkg/util/httpstream/spdy
Checking k8s.io/client-go/listers/extensions/v1beta1
Checking k8s.io/apimachinery/pkg/labels
Checking k8s.io/apimachinery/third_party/forked/golang/json
Checking k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1
Checking github.com/prometheus/procfs
Checking k8s.io/api/storage/v1
Checking k8s.io/api/imagepolicy/v1alpha1
Checking k8s.io/apimachinery/pkg/api/testing/fuzzer
Checking k8s.io/client-go/informers/apps
Checking k8s.io/client-go/listers/batch/v1
Checking gopkg.in/inf.v0
Checking k8s.io/api/batch/v2alpha1
Checking golang.org/x/crypto/ed25519/internal/edwards25519
Checking golang.org/x/net/bpf
Checking k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake
Checking k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake
Checking k8s.io/client-go/listers/events/v1beta1
Checking golang.org/x/text/internal/number
Checking k8s.io/apimachinery/pkg/util/yaml
Checking github.com/golang/protobuf/protoc-gen-go/descriptor
Checking golang.org/x/crypto/blake2b
Checking k8s.io/apimachinery/pkg/apis/meta/v1
Checking github.com/golang/protobuf/jsonpb
Checking k8s.io/api/authentication/v1
Checking k8s.io/apimachinery/pkg/api/errors
Checking k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake
Checking k8s.io/client-go/util/exec
Checking github.com/golang/protobuf/protoc-gen-go/generator
Checking k8s.io/client-go/listers/storage/v1alpha1
Checking github.com/containernetworking/cni/pkg/version/testhelpers
Checking k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1
Checking k8s.io/client-go/informers/policy/v1beta1
Checking github.com/containernetworking/cni/plugins/test/noop/debug
Checking github.com/golang/protobuf/protoc-gen-go/generator/internal/remap
Checking github.com/projectcalico/libcalico-go/lib/validator
Checking k8s.io/client-go/informers/rbac
Checking k8s.io/client-go/kubernetes/typed/events/v1beta1/fake
Checking github.com/golang/protobuf/ptypes/timestamp
===========================================================
The following packages have unknown status licenses (legal
review required). 
===========================================================
github.com/ghodss/yaml:UNKNOWN
```
