### PR TITLE
Adding nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ jobs:
       - attach_workspace:
           at:  /go
       - run: GOOS=linux make build
-      - run: make lint
       - run: make test
       - run:
           command: |
@@ -112,5 +111,6 @@ workflows:
             only:
             - master
     jobs:
+    - lint
     - nightly:
         context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ workflows:
   nightly:
     triggers:
     - schedule:
-        cron: "30 23 * * *"
+        cron: "30 * * * *"
         filters:
           branches:
             only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,5 +114,3 @@ workflows:
     jobs:
     - nightly:
         context: org-global
-        requires:
-          - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
           branches:
             only:
             - master
-  jobs:
+    jobs:
     - lint
     - build
     - nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,11 @@ jobs:
     steps:
       - <<: *initWorkingDir
       - checkout
-      - run: GOOS=linux make build
       - attach_workspace:
           at:  /go
+      - run: GOOS=linux make build
+      - run: make lint
+      - run: make test
       - run:
           command: |
             if [ ! -z "${DOCKER_USER}" ] ; then
@@ -104,14 +106,12 @@ workflows:
   nightly:
     triggers:
     - schedule:
-        cron: "41 * * * *"
+        cron: "30 23 * * *"
         filters:
           branches:
             only:
             - master
     jobs:
-    - lint
-    - build
     - nightly:
         context: org-global
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
   nightly:
     triggers:
     - schedule:
-        cron: "0 12 * * *"
+        cron: "41 * * * *"
         filters:
           branches:
             only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,11 @@ jobs:
           path: /go/out/tests
 
   nightly:
-    <<: *defaults
+    <<: *integrationDefaults
     steps:
       - checkout
       - run: GOOS=linux make build
-     - run:
+      - run:
           command: |
             if [ ! -z "${DOCKER_USER}" ] ; then
               echo "Pushing docker images"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,11 @@ jobs:
   nightly:
     <<: *integrationDefaults
     steps:
+      - <<: *initWorkingDir
       - checkout
       - run: GOOS=linux make build
+      - attach_workspace:
+          at:  /go
       - run:
           command: |
             if [ ! -z "${DOCKER_USER}" ] ; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,20 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
+  nightly:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: GOOS=linux make build
+     - run:
+          command: |
+            if [ ! -z "${DOCKER_USER}" ] ; then
+              echo "Pushing docker images"
+              export TAG=nightly-${CIRCLE_BRANCH}
+              docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+              make docker.push
+            fi
+
 workflows:
   version: 2
 
@@ -82,3 +96,20 @@ workflows:
       - install-cni:
           requires:
             - build
+
+  # Nightly publish
+  nightly:
+    triggers:
+    - schedule:
+        cron: "0 12 * * *"
+        filters:
+          branches:
+            only:
+            - master
+  jobs:
+    - lint
+    - build
+    - nightly:
+        context: org-global
+        requires:
+          - build

--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ approvers:
   - rcurran1
   - jwendell
   - venilnoronha
+  - costin

--- a/OWNERS
+++ b/OWNERS
@@ -7,4 +7,4 @@ approvers:
   - rcurran1
   - jwendell
   - venilnoronha
-  - costin
+  - costinm

--- a/deployments/kubernetes/install/helm/istio-cni/Chart.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/Chart.yaml
@@ -8,6 +8,6 @@ keywords:
   - istio-cni
   - istio
 sources:
-  - http://github.com/istio-ecosystem/cni
+  - http://github.com/istio/cni
 engine: gotpl
 icon: https://istio.io/favicons/android-192x192.png


### PR DESCRIPTION
Once this completes, I'll update the image references to point to istionightly.

I think we can combine lint/build in a single circleci job - in istio/istio things are super slow and need to be in parallel, hopefully we'll not end up in the same state in this repo. 
