### PR TITLE
Add wait and retry logic for iptables call. Fail cni if iptables fail to populate

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -238,7 +238,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 				}
 				if !excludePod {
 					logrus.Infof("setting up redirect")
-					_ = setupRedirect(args.Netns, ports)
+					if err := setupRedirect(args.Netns, ports); err != nil {
+						return err
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Return error if iptables fails to populate
Fix #23

Fix lock collistion

Signed-off-by: Baodong (Robert) Li <baoli@cisco.com>