### PR TITLE
CircleCI DinD job

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,6 @@
+FROM  istio/ci:go1.10-k8s1.10.4-helm2.7.2-minikube0.25
+
+RUN  git clone https://github.com/istio/istio.git /go/src/istio.io/istio
+
+ADD  run_e2e.sh /go/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ defaults: &defaults
 
 dind-env: &dind-env
   DOCKER_VERSION: "17.03.0-ce"
+  CNI_PLUGIN: flannel
 
 # dind docker env
 dind-defaults: &dind-defaults
@@ -174,7 +175,7 @@ jobs:
       - run:
           name: Run e2e test
           command: |
-            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann_rebase' -e CNI_HUB='docker.io/tiswanso' -e HUB='docker.io/tiswanso' -e TAG='nov12' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
+            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann_rebase' -e CNI_HUB='docker.io/tiswanso' -e HUB='gcr.io/istio-release' -e TAG='master-latest-daily' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
       - run:
           name: Display cluster status (2)
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,61 @@ defaults: &defaults
     GOPATH: /go
     SKIP_CLEANUP: true
 
+# dind docker env
+dind-defaults: &dind-defaults
+  docker:
+    - image: istio/ci:go1.10-k8s1.10.4-helm2.7.2-minikube0.25
+  environment:
+    GOPATH: /go
+    SKIP_CLEANUP: true
+  working_directory: ~/kubeadm-dind-cluster
+
+dind-env: &dind-env
+  DOCKER_VERSION: "17.03.0-ce"
+
+dind-setup: &dind-setup
+  name: Set up the environment
+  command: |
+    apt-get -qq update
+    apt-get install -y curl ca-certificates git liblz4-tool rsync socat tzdata
+    curl -sSL -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
+    tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
+    mv /tmp/docker/* /usr/bin
+    # Start port forwarder
+    "${PWD}/build/portforward.sh" start
+
+dind-display_cluster_state: &dind-display_cluster_state
+  command: |
+    DIND_ROOT="$PWD"
+
+    kubectl="kubectl"
+    if [[ ${K8S_SRC:-} ]]; then
+      cd kubernetes
+      kubectl="cluster/kubectl.sh"
+    fi
+
+    apiserver_port="$( "${DIND_ROOT}/dind-cluster.sh" apiserver-port )"
+    "${DIND_ROOT}/build/portforward.sh" -wait "$apiserver_port"
+
+    "${kubectl}" "--server=:${apiserver_port}" version
+    "${kubectl}" "--server=:${apiserver_port}" get all --all-namespaces -o wide
+    "${kubectl}" "--server=:${apiserver_port}" get nodes
+
+dind-dump_cluster: &dind-dump_cluster
+  command: |
+    mkdir -p /tmp/cluster_state
+    out="/tmp/cluster_state/dump-1.gz"
+    if [[ -f ${out} ]]; then
+      out="/tmp/cluster_state/dump-2.gz"
+    fi
+    if [[ ${K8S_SRC:-} ]]; then
+      cd kubernetes
+      ../dind-cluster.sh dump | gzip >"${out}"
+    else
+      ./dind-cluster.sh dump | gzip >"${out}"
+    fi
+
+
 # VM environment. Includes docker.
 integrationDefaults: &integrationDefaults
   machine: true
@@ -84,6 +139,64 @@ jobs:
               TAG=nightly-${CIRCLE_BRANCH} make docker.push
             fi
 
+  e2e-dind:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Get KDC
+          working_directory: ~/kubeadm-dind-cluster
+          command: |
+            git clone https://github.com/kubernetes-sigs/kubeadm-dind-cluster .
+      - run:
+          <<: *dind-setup
+      - run:
+          name: Start kubeadm in DinD (KDC)
+          command: |
+            export DIND_PORT_FORWARDER_WAIT=1
+            export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
+            ./fixed/dind-cluster-v1.10.sh up
+      - run:
+          name: Display cluster status (1)
+          <<: *dind-display_cluster_state
+      - run:
+          name: Dump cluster state (1)
+          when: always
+          <<: *dind-dump_cluster
+      - run:
+          name: Get Istio
+          shell: /bin/bash
+          working_directory: /go/src/istio.io/istio
+          command: |
+            git clone https://github.com/tiswanso/istio.git .
+      - run:
+          name: Run Istio e2e_simple
+          shell: /bin/bash
+          working_directory: /go/src/istio.io/istio
+          command: |
+            HUB=gcr.io/istio-release TAG=master-latest-daily make istioctl
+            HUB=gcr.io/istio-release TAG=master-latest-daily ENABLE_ISTIO_CNI=true EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-mapann --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple
+
+      - run:
+          name: Display cluster status (2)
+          <<: *dind-display_cluster_state
+      - run:
+          name: Dump cluster state (2)
+          when: always
+          <<: *dind-dump_cluster
+      - store_artifacts:
+          path: /tmp/cluster_state
+      - run:
+          name: Bring down the cluster
+          command: |
+            ./dind-cluster.sh down
+      - run:
+          name: Clean the cluster
+          command: |
+            ./dind-cluster.sh clean
+
 workflows:
   version: 2
 
@@ -93,6 +206,7 @@ workflows:
       - install-cni:
           requires:
             - build
+      - e2e-dind
 
   # Nightly publish
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,12 @@ jobs:
       - checkout:
           path: /go/src/istio.io/cni
       - run:
+          name: Build istio-cni
+          working_directory: /go/src/istio.io/cni
+          command: |
+            GOOS=linux make build
+            TAG=${CIRCLE_SHA1} GOOS=linux make docker.all
+      - run:
           name: Build test-e2e container
           working_directory: /go/src/istio.io/cni
           command: |
@@ -175,7 +181,7 @@ jobs:
       - run:
           name: Run e2e test
           command: |
-            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann_rebase' -e CNI_HUB='docker.io/tiswanso' -e HUB='gcr.io/istio-release' -e TAG='master-latest-daily' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
+            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='istio' -e HUB='gcr.io/istio-release' -e TAG='master-latest-daily' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
       - run:
           name: Display cluster status (2)
           when: always
@@ -204,7 +210,9 @@ workflows:
       - install-cni:
           requires:
             - build
-      - e2e-dind
+      - e2e-dind:
+          requires:
+            - build
 
   # Nightly publish
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,6 @@ dind-setup: &dind-setup
   command: |
     sudo apt-get -qq update
     sudo apt-get install -y curl ca-certificates git liblz4-tool rsync socat tzdata
-    #curl -sSL -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
-    #tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
-    #sudo mv /tmp/docker/* /usr/bin
     # Start port forwarder
     "${PWD}/build/portforward.sh" start
 
@@ -99,7 +96,19 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: GOOS=linux make build
+      - setup_remote_docker
+      - run:
+          name: Build docker images
+          command: |
+            TAG=${CIRCLE_SHA1} GOOS=linux make build
+            TAG=${CIRCLE_SHA1} GOOS=linux make docker
+            images_to_save+=("docker.io/istio/install-cni:${CIRCLE_SHA1}")
+            mkdir -p _save
+            docker save "${images_to_save[@]}" >_save/images.tar
+      - persist_to_workspace:
+          root: _save
+          paths:
+          - images.tar
       - run: make lint
 
   install-cni:
@@ -147,12 +156,8 @@ jobs:
       - setup_remote_docker
       - checkout:
           path: /go/src/istio.io/cni
-      - run:
-          name: Build istio-cni
-          working_directory: /go/src/istio.io/cni
-          command: |
-            GOOS=linux make build
-            TAG=${CIRCLE_SHA1} GOOS=linux make docker.all
+      - attach_workspace:
+          at: /go/src/_save
       - run:
           name: Build test-e2e container
           working_directory: /go/src/istio.io/cni
@@ -179,9 +184,17 @@ jobs:
           when: always
           <<: *dind-dump_cluster
       - run:
+          name: Restore built images
+          command: |
+            for node in kube-master kube-node-1 kube-node-2; do
+              docker cp /go/src/_save/images.tar $node:/images.tar
+              docker exec -t $node sh -c "docker load -i /images.tar"
+              docker exec -t $node sh -c "docker images"
+            done
+      - run:
           name: Run e2e test
           command: |
-            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='istio' -e HUB='gcr.io/istio-release' -e TAG='master-latest-daily' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
+            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB='gcr.io/istio-release' -e TAG='master-latest-daily' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
       - run:
           name: Display cluster status (2)
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,13 @@ jobs:
     <<: *dind-defaults
     steps:
       - setup_remote_docker
+      - checkout:
+          path: /go/src/istio.io/cni
+      - run:
+          name: Build test-e2e container
+          working_directory: /go/src/istio.io/cni
+          command: |
+            docker build -t e2e-runner:latest .circleci
       - run:
           name: Get KDC
           working_directory: ~/kubeadm-dind-cluster
@@ -165,23 +172,9 @@ jobs:
           when: always
           <<: *dind-dump_cluster
       - run:
-          name: Get Istio
-          shell: /bin/bash
-          working_directory: /go/src/istio.io/istio
+          name: Run e2e test
           command: |
-            git clone https://github.com/istio/istio.git .
-      - run:
-          name: Run Istio e2e_simple
-          shell: /bin/bash
-          working_directory: /go/src/istio.io/istio
-          command: |
-            GOOS=linux HUB=gcr.io/istio-release TAG=master-latest-daily make istioctl
-            # setup port forwarding for kubectl to work with KDC cluster
-            DIND_ROOT=~/kubeadm-dind-cluster
-            apiserver_port="$( "${DIND_ROOT}/dind-cluster.sh" apiserver-port )"
-            "${DIND_ROOT}/build/portforward.sh" -wait "$apiserver_port"
-            HUB=gcr.io/istio-release TAG=master-latest-daily ENABLE_ISTIO_CNI=false EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.hub=istio --set istio-cni.tag=${CIRCLE_SHA1} --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple
-
+            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann' e2e-runner:latest /go/run_e2e.sh
       - run:
           name: Display cluster status (2)
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,15 @@ jobs:
           working_directory: /go/src/istio.io/istio
           command: |
             GOOS=linux HUB=gcr.io/istio-release TAG=master-latest-daily make istioctl
-            HUB=gcr.io/istio-release TAG=master-latest-daily ENABLE_ISTIO_CNI=true EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-mapann --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple
+            # setup port forwarding for kubectl to work with KDC cluster
+            DIND_ROOT=~/kubeadm-dind-cluster
+            apiserver_port="$( "${DIND_ROOT}/dind-cluster.sh" apiserver-port )"
+            "${DIND_ROOT}/build/portforward.sh" -wait "$apiserver_port"
+            HUB=gcr.io/istio-release TAG=master-latest-daily ENABLE_ISTIO_CNI=false EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.hub=istio --set istio-cni.tag=${CIRCLE_SHA1} --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple
 
       - run:
           name: Display cluster status (2)
+          when: always
           <<: *dind-display_cluster_state
       - run:
           name: Dump cluster state (2)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - run:
           name: Run e2e test
           command: |
-            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann_rebase' -e HUB='docker.io/tiswanso' -e TAG='nov12' e2e-runner:latest /go/run_e2e.sh
+            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann_rebase' -e CNI_HUB='docker.io/tiswanso' -e HUB='docker.io/tiswanso' -e TAG='nov12' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
       - run:
           name: Display cluster status (2)
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - run:
           name: Run e2e test
           command: |
-            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann' e2e-runner:latest /go/run_e2e.sh
+            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG='v0.1-dev-mapann_rebase' -e HUB='docker.io/tiswanso' -e TAG='nov12' e2e-runner:latest /go/run_e2e.sh
       - run:
           name: Display cluster status (2)
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ defaults: &defaults
     GOPATH: /go
     SKIP_CLEANUP: true
 
+dind-env: &dind-env
+  DOCKER_VERSION: "17.03.0-ce"
+
 # dind docker env
 dind-defaults: &dind-defaults
   docker:
@@ -16,19 +19,17 @@ dind-defaults: &dind-defaults
   environment:
     GOPATH: /go
     SKIP_CLEANUP: true
+    <<: *dind-env
   working_directory: ~/kubeadm-dind-cluster
-
-dind-env: &dind-env
-  DOCKER_VERSION: "17.03.0-ce"
 
 dind-setup: &dind-setup
   name: Set up the environment
   command: |
-    apt-get -qq update
-    apt-get install -y curl ca-certificates git liblz4-tool rsync socat tzdata
-    curl -sSL -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
-    tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
-    mv /tmp/docker/* /usr/bin
+    sudo apt-get -qq update
+    sudo apt-get install -y curl ca-certificates git liblz4-tool rsync socat tzdata
+    #curl -sSL -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
+    #tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
+    #sudo mv /tmp/docker/* /usr/bin
     # Start port forwarder
     "${PWD}/build/portforward.sh" start
 
@@ -141,8 +142,6 @@ jobs:
 
   e2e-dind:
     <<: *dind-defaults
-    environment:
-      <<: *dind-env
     steps:
       - setup_remote_docker
       - run:
@@ -170,13 +169,13 @@ jobs:
           shell: /bin/bash
           working_directory: /go/src/istio.io/istio
           command: |
-            git clone https://github.com/tiswanso/istio.git .
+            git clone https://github.com/istio/istio.git .
       - run:
           name: Run Istio e2e_simple
           shell: /bin/bash
           working_directory: /go/src/istio.io/istio
           command: |
-            HUB=gcr.io/istio-release TAG=master-latest-daily make istioctl
+            GOOS=linux HUB=gcr.io/istio-release TAG=master-latest-daily make istioctl
             HUB=gcr.io/istio-release TAG=master-latest-daily ENABLE_ISTIO_CNI=true EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-mapann --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple
 
       - run:

--- a/.circleci/run_e2e.sh
+++ b/.circleci/run_e2e.sh
@@ -10,4 +10,4 @@ TAG=${TAG:-master-latest-daily}
 
 HUB=${HUB} TAG=${TAG} make istioctl
 
-HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=false EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.hub=${CNI_HUB} --set istio-cni.tag=${CNI_TAG} --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple
+HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=true EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.hub=${CNI_HUB} --set istio-cni.tag=${CNI_TAG} --set istio-cni.pullPolicy=IfNotPresent --set istio-cni.logLevel=${CNI_LOGLVL:-debug}" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector ${SKIP_CLEAN:+ --skip_cleanup}" make test/local/auth/e2e_simple

--- a/.circleci/run_e2e.sh
+++ b/.circleci/run_e2e.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+CNI_HUB=${CNI_HUB:-istio}
+CNI_TAG=${CNI_TAG:-$1}
+
+cd /go/src/istio.io/istio
+
+HUB=${HUB:-gcr.io/istio-release}
+TAG=${TAG:-master-latest-daily}
+
+HUB=${HUB} TAG=${TAG} make istioctl
+
+HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=false EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.hub=${CNI_HUB} --set istio-cni.tag=${CNI_TAG} --set istio-cni.pullPolicy=IfNotPresent" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple


### PR DESCRIPTION
CircleCI with k8s on DinD similar to KDC repo--https://github.com/kubernetes-sigs/kubeadm-dind-cluster

1. use circleci remote_docker in the same pattern as KDC's circleci jobs to install a multi-node k8s cluster with flannel CNI.
1. save/restore install-cni docker image under-test from build job.  Copy images into each k8s node's docker cache
1. build a container with Istio master to run Istio e2e tests from the same docker network space as the DinD k8s' kube-master container ("node").  see run_e2e.sh
    1. run e2e_simple tests with Istio CNI enabled
1.  collect and copy out k8s state to circleci artifacts
