### PR TITLE
Attach the workspace to the /Users/tiswanso/go-istio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - <<: *initWorkingDir
       - checkout
+      - attach_workspace:
+          at:  /go
       - run: GOOS=linux make build
       - run: make docker.all
       - run: make test


### PR DESCRIPTION
The nightly is having a problem with the working dir and GOPATH for the make build step.  Fix is to attach the workspace at the right location.