### PR TITLE
circleci: fix nightly job clobber of the build/test env settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,23 +69,19 @@ jobs:
 
   nightly:
     <<: *integrationDefaults
-    environment:
-      - TAG: nightly-${CIRCLE_BRANCH}
     steps:
       - <<: *initWorkingDir
       - checkout
-      - attach_workspace:
-          at:  /go
       - run: GOOS=linux make build
-      - run: make docker.all
-      - run: make test
+      - run: TAG=nightly-${CIRCLE_BRANCH} make docker.all
+      - run: TAG=nightly-${CIRCLE_BRANCH} make test
       - run:
           command: |
             if [ ! -z "${DOCKER_USER}" ] ; then
               echo "Pushing docker images"
 
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-              make docker.push
+              TAG=nightly-${CIRCLE_BRANCH} make docker.push
             fi
 
 workflows:


### PR DESCRIPTION
The yaml macros for the nightly job's env settings were getting clobbered by the subsequent use of the "environment:" key containing the TAG setting.  Yaml doesn't do an auto-merge of dicts/maps :-)

Changed to put the tag setting in each command-line for now to make it clear.

**Troubleshooting note:**  use the circleci "configuration" tab on the job view to see the resulting yaml that circleci sees--it has the result of using all those yaml inline macros (references/aliases).