### PR TITLE
Run nightly only at 09:45am UTC and include e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,10 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
+  # nightly test & publish
+  # NOTE: publish only happens for CircleCI orgs with DOCKER_USER & DOCKER_PASS set.
+  #       Istio currently does not use CircleCI to publish nightly.  Nightly artifacts
+  #       are published by istio/istio/release tooling & go to gcr.io/istio-release.
   nightly:
     <<: *integrationDefaults
     steps:
@@ -227,11 +231,12 @@ workflows:
           requires:
             - build
 
-  # Nightly publish
+  # Nightly test
   nightly:
     triggers:
     - schedule:
-        cron: "30 * * * *"
+        # run at 09:45:00 UTC to try to pickup Istio's nightly
+        cron: "45 9 * * *"
         filters:
           branches:
             only:
@@ -240,5 +245,8 @@ workflows:
     - build
     - nightly:
         context: org-global
+        requires:
+          - build
+    - e2e-dind:
         requires:
           - build


### PR DESCRIPTION
change it from running every hour on the half past mark.  Only run it nightly at 09:45:00 UTC to try to ensure it picks up Istio's nightly release for testing--istio nightly seems to run at ~09:15 UTC.

Also include the DinD e2e test in the nightly run.