### PR TITLE
CircleCI e2e test against Istio release1.1 branch

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,6 +1,7 @@
 FROM  istio/ci:go1.10-k8s1.10.4-helm2.7.2-minikube0.25
+ARG  istio_branch=master
 
-RUN  git clone https://github.com/istio/istio.git /go/src/istio.io/istio
+RUN  git clone --branch $istio_branch https://github.com/istio/istio.git /go/src/istio.io/istio
 
 ADD  run_e2e.sh /go/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,15 @@ defaults: &defaults
     SKIP_CLEANUP: true
 
 dind-env: &dind-env
+  GOPATH: /go
+  SKIP_CLEANUP: true
   DOCKER_VERSION: "17.03.0-ce"
   CNI_PLUGIN: flannel
 
-# dind docker env
+# dind default setup
 dind-defaults: &dind-defaults
   docker:
     - image: istio/ci:go1.10-k8s1.10.4-helm2.7.2-minikube0.25
-  environment:
-    GOPATH: /go
-    SKIP_CLEANUP: true
-    <<: *dind-env
   working_directory: ~/kubeadm-dind-cluster
 
 dind-setup: &dind-setup
@@ -91,6 +89,72 @@ initWorkingDir: &initWorkingDir
     sudo mkdir $GOROOT
     curl https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
+# The common steps for running kubeadm-dind-clusters and istio e2e tests
+e2e-dind-test: &e2e-dind-test
+  steps:
+    - setup_remote_docker
+    - checkout:
+        path: /go/src/istio.io/cni
+    - attach_workspace:
+        at: /go/src/_save
+    - run:
+        name: Build test-e2e container
+        working_directory: /go/src/istio.io/cni
+        command: |
+          docker build --build-arg istio_branch=${ISTIO_BRANCH:-master} -t e2e-runner:latest .circleci
+    - run:
+        name: Get KDC
+        working_directory: ~/kubeadm-dind-cluster
+        command: |
+          git clone https://github.com/kubernetes-sigs/kubeadm-dind-cluster .
+    - run:
+        <<: *dind-setup
+    - run:
+        name: Start kubeadm in DinD (KDC)
+        command: |
+          export DIND_PORT_FORWARDER_WAIT=1
+          export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
+          ./fixed/dind-cluster-v1.10.sh up
+    - run:
+        name: Display cluster status (1)
+        <<: *dind-display_cluster_state
+    - run:
+        name: Dump cluster state (1)
+        when: always
+        <<: *dind-dump_cluster
+    - run:
+        name: Restore built images
+        command: |
+          for node in kube-master kube-node-1 kube-node-2; do
+            docker cp /go/src/_save/images.tar $node:/images.tar
+            docker exec -t $node sh -c "docker load -i /images.tar"
+            docker exec -t $node sh -c "docker images"
+          done
+    - run:
+        name: Run e2e test
+        command: |
+          docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB=${ISTIO_HUB:-gcr.io/istio-release} -e TAG=${ISTIO_TAG:-master-latest-daily} -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
+    - run:
+        name: Display cluster status (2)
+        when: always
+        <<: *dind-display_cluster_state
+    - run:
+        name: Dump cluster state (2)
+        when: always
+        <<: *dind-dump_cluster
+    - store_artifacts:
+        path: /tmp/cluster_state
+    - run:
+        name: Bring down the cluster
+        command: |
+          ./dind-cluster.sh down
+    - run:
+        name: Clean the cluster
+        command: |
+          ./dind-cluster.sh clean
+
+
+
 jobs:
   build:
     <<: *defaults
@@ -154,69 +218,23 @@ jobs:
               TAG=nightly-${CIRCLE_BRANCH} make docker.push
             fi
 
+  e2e-dind-istio1.1:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      ISTIO_BRANCH: release-1.1
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: release-1.1-latest-daily
+    <<: *e2e-dind-test  
+
   e2e-dind:
     <<: *dind-defaults
-    steps:
-      - setup_remote_docker
-      - checkout:
-          path: /go/src/istio.io/cni
-      - attach_workspace:
-          at: /go/src/_save
-      - run:
-          name: Build test-e2e container
-          working_directory: /go/src/istio.io/cni
-          command: |
-            docker build -t e2e-runner:latest .circleci
-      - run:
-          name: Get KDC
-          working_directory: ~/kubeadm-dind-cluster
-          command: |
-            git clone https://github.com/kubernetes-sigs/kubeadm-dind-cluster .
-      - run:
-          <<: *dind-setup
-      - run:
-          name: Start kubeadm in DinD (KDC)
-          command: |
-            export DIND_PORT_FORWARDER_WAIT=1
-            export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
-            ./fixed/dind-cluster-v1.10.sh up
-      - run:
-          name: Display cluster status (1)
-          <<: *dind-display_cluster_state
-      - run:
-          name: Dump cluster state (1)
-          when: always
-          <<: *dind-dump_cluster
-      - run:
-          name: Restore built images
-          command: |
-            for node in kube-master kube-node-1 kube-node-2; do
-              docker cp /go/src/_save/images.tar $node:/images.tar
-              docker exec -t $node sh -c "docker load -i /images.tar"
-              docker exec -t $node sh -c "docker images"
-            done
-      - run:
-          name: Run e2e test
-          command: |
-            docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB='gcr.io/istio-release' -e TAG='master-latest-daily' -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
-      - run:
-          name: Display cluster status (2)
-          when: always
-          <<: *dind-display_cluster_state
-      - run:
-          name: Dump cluster state (2)
-          when: always
-          <<: *dind-dump_cluster
-      - store_artifacts:
-          path: /tmp/cluster_state
-      - run:
-          name: Bring down the cluster
-          command: |
-            ./dind-cluster.sh down
-      - run:
-          name: Clean the cluster
-          command: |
-            ./dind-cluster.sh clean
+    environment:
+      <<: *dind-env
+      ISTIO_BRANCH: master
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
+    <<: *e2e-dind-test
 
 workflows:
   version: 2
@@ -228,6 +246,9 @@ workflows:
           requires:
             - build
       - e2e-dind:
+          requires:
+            - build
+      - e2e-dind-istio1.1:
           requires:
             - build
 
@@ -248,5 +269,8 @@ workflows:
         requires:
           - build
     - e2e-dind:
+        requires:
+          - build
+    - e2e-dind-istio1.1:
         requires:
           - build

--- a/.circleci/run_e2e.sh
+++ b/.circleci/run_e2e.sh
@@ -10,4 +10,11 @@ TAG=${TAG:-master-latest-daily}
 
 HUB=${HUB} TAG=${TAG} make istioctl
 
+# Remove any pre-existing charts
+# ...This seems to get around an issue seen with 1.1 where helm dep update fails with:
+# /go/out/linux_amd64/release/helm dep update --skip-refresh install/kubernetes/helm/istio
+#
+# Error: Unable to move current charts to tmp dir: rename /go/src/istio.io/istio/install/kubernetes/helm/istio/charts /go/src/istio.io/istio/install/kubernetes/helm/istio/tmpcharts: invalid cross-device link
+rm -rf /go/src/istio.io/istio/install/kubernetes/helm/istio/charts
+
 HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=true EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.hub=${CNI_HUB} --set istio-cni.tag=${CNI_TAG} --set istio-cni.pullPolicy=IfNotPresent --set istio-cni.logLevel=${CNI_LOGLVL:-debug}" E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector ${SKIP_CLEAN:+ --skip_cleanup}" make test/local/auth/e2e_simple


### PR DESCRIPTION
Add a e2e DinD job for testing with Istio release 1.1.
  - Build e2e_runner with istio release1.1 content
  - trigger e2e with Istio release1.1 nightly images 