### PR TITLE
WIP--CircleCI: add jobs to run e2e_simple against other base CNI plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ dind-env: &dind-env
   GOPATH: /go
   SKIP_CLEANUP: true
   DOCKER_VERSION: "17.03.0-ce"
-  CNI_PLUGIN: flannel
 
 # dind default setup
 dind-defaults: &dind-defaults
@@ -224,6 +223,7 @@ jobs:
     <<: *dind-defaults
     environment:
       <<: *dind-env
+      CNI_PLUGIN: flannel
       ISTIO_BRANCH: release-1.1
       ISTIO_HUB: gcr.io/istio-release
       ISTIO_TAG: release-1.1-latest-daily
@@ -233,9 +233,40 @@ jobs:
     <<: *dind-defaults
     environment:
       <<: *dind-env
+      CNI_PLUGIN: flannel
       ISTIO_BRANCH: master
       ISTIO_HUB: gcr.io/istio-release
       ISTIO_TAG: master-latest-daily
+    <<: *e2e-dind-test
+
+  e2e-dind-istio1.1-calico:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      CNI_PLUGIN: calico
+      ISTIO_BRANCH: release-1.1
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: release-1.1-latest-daily
+    <<: *e2e-dind-test
+
+  e2e-dind-istio1.1-weave:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      CNI_PLUGIN: weave
+      ISTIO_BRANCH: release-1.1
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: release-1.1-latest-daily
+    <<: *e2e-dind-test
+
+  e2e-dind-istio1.1-calico_kdd:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      CNI_PLUGIN: calico-kdd
+      ISTIO_BRANCH: release-1.1
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: release-1.1-latest-daily
     <<: *e2e-dind-test
 
 workflows:
@@ -251,6 +282,15 @@ workflows:
           requires:
             - build
       - e2e-dind-istio1.1:
+          requires:
+            - build
+      - e2e-dind-istio1.1-calico:
+          requires:
+            - build
+      - e2e-dind-istio1.1-weave:
+          requires:
+            - build
+      - e2e-dind-istio1.1-calico_kdd:
           requires:
             - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,36 @@ jobs:
       ISTIO_TAG: release-1.1-latest-daily
     <<: *e2e-dind-test
 
+  e2e-dind-calico:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      CNI_PLUGIN: calico
+      ISTIO_BRANCH: master
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
+    <<: *e2e-dind-test
+
+  e2e-dind-weave:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      CNI_PLUGIN: weave
+      ISTIO_BRANCH: master
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
+    <<: *e2e-dind-test
+
+  e2e-dind-calico_kdd:
+    <<: *dind-defaults
+    environment:
+      <<: *dind-env
+      CNI_PLUGIN: calico-kdd
+      ISTIO_BRANCH: master
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
+    <<: *e2e-dind-test
+
 workflows:
   version: 2
 
@@ -293,6 +323,16 @@ workflows:
       - e2e-dind-istio1.1-calico_kdd:
           requires:
             - build
+      - e2e-dind-calico:
+          requires:
+            - build
+      - e2e-dind-weave:
+          requires:
+            - build
+      - e2e-dind-calico_kdd:
+          requires:
+            - build
+
 
   # Nightly test
   nightly:
@@ -314,5 +354,23 @@ workflows:
         requires:
           - build
     - e2e-dind-istio1.1:
+        requires:
+          - build
+    - e2e-dind-istio1.1-calico:
+        requires:
+          - build
+    - e2e-dind-istio1.1-weave:
+        requires:
+          - build
+    - e2e-dind-istio1.1-calico_kdd:
+        requires:
+          - build
+    - e2e-dind-calico:
+        requires:
+          - build
+    - e2e-dind-weave:
+        requires:
+          - build
+    - e2e-dind-calico_kdd:
         requires:
           - build


### PR DESCRIPTION
Current jobs run with flannel as the base CNI plugin.  KDC supports installing others so add calico, weave, & calico_kdd jobs here.