### PR TITLE
Fix build info and other references to user tiswanso in misc places.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ of hosted Kubernetes environments and whether `istio-cni` has been trialed in th
 1. Enable [network-policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) in your cluster.  NOTE: for existing clusters this redeploys the nodes.
 
 1. Make sure your kubectl user (service-account) has a ClusterRoleBinding to the `cluster-admin` role.  This is also a typical pre-requisite for installing Istio on GKE.
-   1. `kubectl create clusterrolebinding cni-cluster-admin-binding --clusterrole=cluster-admin --user=tiswanso@gmail.com`
-      1. User `tiswanso@gmail.com` is an admin user associated with the gcloud GKE cluster
+   1. `kubectl create clusterrolebinding cni-cluster-admin-binding --clusterrole=cluster-admin --user=istio-user@gmail.com`
+      1. User `istio-user@gmail.com` is an admin user associated with the gcloud GKE cluster
 
 1. Install Istio via Helm including these options `--set istio_cni.enabled=true --set istio-cni.cniBinDir=/home/kubernetes/bin`
 
@@ -142,7 +142,7 @@ $ ISTIO_CNI_RELPATH=github.com/some/cni GOOS=linux make build
 To push the Docker image:
 
 ```console
-$ export HUB=docker.io/tiswanso
+$ export HUB=docker.io/myuser
 $ export TAG=dev
 $ GOOS=linux make docker.push
 ```

--- a/bin/get_workspace_status.sh
+++ b/bin/get_workspace_status.sh
@@ -46,9 +46,9 @@ if [[ -n ${ISTIO_DOCKER_HUB} ]]; then
 fi
 
 # used by bin/gobuild.sh
-echo "github.com/tiswanso/istio-cni/pkg/version.buildVersion=${VERSION}"
-echo "github.com/tiswanso/istio-cni/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
-echo "github.com/tiswanso/istio-cni/pkg/version.buildUser=$(whoami)"
-echo "github.com/tiswanso/istio-cni/pkg/version.buildHost=$(hostname -f)"
-echo "github.com/tiswanso/istio-cni/pkg/version.buildDockerHub=${DOCKER_HUB}"
-echo "github.com/tiswanso/istio-cni/pkg/version.buildStatus=${tree_status}"
+echo "istio.io/cni/pkg/version.buildVersion=${VERSION}"
+echo "istio.io/cni/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
+echo "istio.io/cni/pkg/version.buildUser=$(whoami)"
+echo "istio.io/cni/pkg/version.buildHost=$(hostname -f)"
+echo "istio.io/cni/pkg/version.buildDockerHub=${DOCKER_HUB}"
+echo "istio.io/cni/pkg/version.buildStatus=${tree_status}"

--- a/deployments/kubernetes/Dockerfile.install-cni
+++ b/deployments/kubernetes/Dockerfile.install-cni
@@ -1,6 +1,6 @@
 FROM amd64/alpine:3.8
 
-LABEL maintainer "Tim Swanson <tiswanso@cisco.com"
+LABEL description="Istio CNI plugin installer."
 
 # add bash to allow install-cni.sh to trap process signals
 RUN apk --update add jq bash && \

--- a/test/install_k8s_test.go
+++ b/test/install_k8s_test.go
@@ -29,8 +29,8 @@ var (
 	PreConfDir      = "data/pre"
 	ExpectedConfDir = "data/expected"
 	TestWorkDir, _  = os.Getwd()
-	Hub             = "docker.io/tiswanso"
-	Tag             = "v0.1-cleanup"
+	Hub             = "gcr.io/istio-release"
+	Tag             = "master-latest-daily"
 )
 
 type testCase struct {


### PR DESCRIPTION
leaving the references in the helm defaults (values.yaml) since we don't yet have a process that pushes to gcr.io/istio-release yet.