### PR TITLE
Point hub and tag to istio-release

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/values.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values.yaml
@@ -1,5 +1,5 @@
-hub: docker.io/tiswanso
-tag: v0.1-dev
+hub: gcr.io/istio-release
+tag: master-latest-daily
 pullPolicy: Always
 
 logLevel: info

--- a/test/README.md
+++ b/test/README.md
@@ -134,6 +134,12 @@ To run the Istio e2e test first, clone the Istio repo in your local environment.
 ```console
 make e2e_simple_cni
 ```
+This runs the `e2e_simple` with the latest nightly CNI image pushed to gcr.io/istio-release.  The HUB and TAG value can be overridden using the environement variables:
+```console
+export ISTIO_CNI_HUB=yourhub
+export ISTIO_CNI_TAG=yourtag
+```
+
 
 2. Run any of the Istio e2e targets after setting up a few environment variables:
 ```console


### PR DESCRIPTION
Nightly images are available on gcr.io/istio-release
point to that as the default.