### PR TITLE
Fix typo in comment

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -70,7 +70,7 @@ type PluginConf struct {
 	RawPrevResult *map[string]interface{} `json:"prevResult"`
 	PrevResult    *current.Result         `json:"-"`
 
-	// Add plugin-specifc flags here
+	// Add plugin-specific flags here
 	LogLevel   string     `json:"log_level"`
 	Kubernetes Kubernetes `json:"kubernetes"`
 }


### PR DESCRIPTION
Fix typo in comment: "plugin-specifc" to "plugin-specific" in line 73.