### PR TITLE
Check for Sidecar Annotation Before Redirect

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -37,6 +37,7 @@ var (
 	nsSetupProg   = "istio-iptables.sh"
 
 	injectAnnotationKey = "sidecar.istio.io/inject"
+	injectIstioKey      = "sidecar.istio.io/status"
 )
 
 // setupRedirect is a unit test override variable.
@@ -202,6 +203,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 							excludePod = true
 						}
 					}
+				}
+				if val, ok := annotations[injectIstioKey]; !ok {
+					logrus.Infof("Pod %s excluded due to not containing sidecar annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
+					excludePod = true
 				}
 				if !excludePod {
 					logrus.Infof("setting up redirect")

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -216,6 +216,26 @@ func TestCmdAddTwoContainers(t *testing.T) {
 	}
 }
 
+func TestCmdAddTwoContainersWithSideCar(t *testing.T) {
+	defer resetGlobalTestVariables()
+
+	testContainers = []string{"mockContainer", "mockContainer2"}
+	testAnnotations[injectIstioKey] = "true"
+
+	testCmdAdd(t)
+
+	if !nsenterFuncCalled {
+		t.Fatalf("expected nsenterFunc to be called")
+	}
+}
+
+func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
+	defer resetGlobalTestVariables()
+
+	testContainers = []string{"mockContainer", "mockContainer2"}
+	testCmdAdd(t)
+}
+
 func TestCmdAddExcludePod(t *testing.T) {
 	defer resetGlobalTestVariables()
 

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -207,20 +207,8 @@ func TestCmdAddTwoContainers(t *testing.T) {
 
 	setupRedirect = mockNsenterRedirect
 	testAnnotations[injectAnnotationKey] = "true"
-	testContainers = []string{"mockContainer", "mockContainer2"}
-
-	testCmdAdd(t)
-
-	if !nsenterFuncCalled {
-		t.Fatalf("expected nsenterFunc to be called")
-	}
-}
-
-func TestCmdAddTwoContainersWithSideCar(t *testing.T) {
-	defer resetGlobalTestVariables()
-
-	testContainers = []string{"mockContainer", "mockContainer2"}
 	testAnnotations[injectIstioKey] = "true"
+	testContainers = []string{"mockContainer", "mockContainer2"}
 
 	testCmdAdd(t)
 

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -48,14 +48,15 @@ const (
 
 var (
 	annotationRegistry = map[string]*annotationParam{
-		"inject":         {injectAnnotationKey, "", alwaysValidFunc},
-		"status":         {sidecarStatusKey, "", alwaysValidFunc},
-		"redirectMode":   {sidecarInterceptModeKey, defaultRedirectMode, validateInterceptionMode},
-		"ports":          {sidecarPortListKey, "", validatePortList},
-		"includeIPCidrs": {includeIPCidrsKey, defaultRedirectIPCidr, validateCIDRListWithWildcard},
-		"excludeIPCidrs": {excludeIPCidrsKey, defaultRedirectExcludeIPCidr, validateCIDRList},
-		"includePorts":   {includePortsKey, "", validatePortListWithWildcard},
-		"excludePorts":   {excludePortsKey, defaultRedirectExcludePort, validatePortList},
+		"inject":          {injectAnnotationKey, "", alwaysValidFunc},
+		"injectNoSidecar": {injectIstioKey, "", alwaysValidFunc},
+		"status":          {sidecarStatusKey, "", alwaysValidFunc},
+		"redirectMode":    {sidecarInterceptModeKey, defaultRedirectMode, validateInterceptionMode},
+		"ports":           {sidecarPortListKey, "", validatePortList},
+		"includeIPCidrs":  {includeIPCidrsKey, defaultRedirectIPCidr, validateCIDRListWithWildcard},
+		"excludeIPCidrs":  {excludeIPCidrsKey, defaultRedirectExcludeIPCidr, validateCIDRList},
+		"includePorts":    {includePortsKey, "", validatePortListWithWildcard},
+		"excludePorts":    {excludePortsKey, defaultRedirectExcludePort, validatePortList},
 	}
 )
 


### PR DESCRIPTION
Hello, 

We had a scenario in our cluster were a pod got IP Rules when it did not have the sidecar, to prevent this I have added a check to make sure that the pod has a status annotation, which will only be present if there is a sidecar.

Feedback Welcome! 

Thank You