### PR TITLE
Check for Sidecar Annotation Before Redirect

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -37,7 +37,7 @@ var (
 	nsSetupProg   = "istio-iptables.sh"
 
 	injectAnnotationKey = "sidecar.istio.io/inject"
-	injectIstioKey      = "sidecar.istio.io/status"
+	sidecarStatusKey    = "sidecar.istio.io/status"
 )
 
 // setupRedirect is a unit test override variable.
@@ -204,8 +204,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 						}
 					}
 				}
-				if val, ok := annotations[injectIstioKey]; !ok {
-					logrus.Infof("Pod %s excluded due to not containing sidecar annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
+				if _, ok := annotations[sidecarStatusKey]; !ok {
+					logrus.Infof("Pod %s excluded due to not containing sidecar annotation", string(k8sArgs.K8S_POD_NAME))
 					excludePod = true
 				}
 				if !excludePod {

--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -37,6 +37,7 @@ var (
 	nsSetupProg   = "istio-iptables.sh"
 
 	injectAnnotationKey = "sidecar.istio.io/inject"
+	injectIstioKey      = "sidecar.istio.io/status"
 )
 
 // setupRedirect is a unit test override variable.
@@ -202,6 +203,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 							excludePod = true
 						}
 					}
+				}
+				if val, ok := annotations[injectIstioKey]; !ok {
+					logrus.Infof("Pod %s excluded due to not containing sidecar annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
+					excludePod = true
 				}
 				if !excludePod {
 					logrus.Infof("setting up redirect")

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -207,6 +207,7 @@ func TestCmdAddTwoContainers(t *testing.T) {
 
 	setupRedirect = mockNsenterRedirect
 	testAnnotations[injectAnnotationKey] = "true"
+	testAnnotations[injectIstioKey] = "true"
 	testContainers = []string{"mockContainer", "mockContainer2"}
 
 	testCmdAdd(t)
@@ -214,6 +215,13 @@ func TestCmdAddTwoContainers(t *testing.T) {
 	if !nsenterFuncCalled {
 		t.Fatalf("expected nsenterFunc to be called")
 	}
+}
+
+func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
+	defer resetGlobalTestVariables()
+
+	testContainers = []string{"mockContainer", "mockContainer2"}
+	testCmdAdd(t)
 }
 
 func TestCmdAddExcludePod(t *testing.T) {

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -123,6 +123,7 @@ func resetGlobalTestVariables() {
 	testPorts = []string{"9080"}
 
 	setupRedirect = nil
+	testAnnotations[sidecarStatusKey] = "true"
 }
 
 func testSetArgs(stdinData string) *skel.CmdArgs {
@@ -207,7 +208,6 @@ func TestCmdAddTwoContainers(t *testing.T) {
 
 	setupRedirect = mockNsenterRedirect
 	testAnnotations[injectAnnotationKey] = "true"
-	testAnnotations[sidecarStatusKey] = "true"
 	testContainers = []string{"mockContainer", "mockContainer2"}
 
 	testCmdAdd(t)
@@ -220,8 +220,13 @@ func TestCmdAddTwoContainers(t *testing.T) {
 func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
 	defer resetGlobalTestVariables()
 
+	testAnnotations = nil
 	testContainers = []string{"mockContainer", "mockContainer2"}
 	testCmdAdd(t)
+
+	if nsenterFuncCalled {
+		t.Fatalf("Didnt Expect nsenterFunc to be called, this pod does not contain a sidecar")
+	}
 }
 
 func TestCmdAddExcludePod(t *testing.T) {

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -225,7 +225,7 @@ func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
 	testCmdAdd(t)
 
 	if nsenterFuncCalled {
-		t.Fatalf("Didnt Expect nsenterFunc to be called, this pod does not contain a sidecar")
+		t.Fatalf("Didnt Expect nsenterFunc to be called because this pod does not contain a sidecar")
 	}
 }
 

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -207,7 +207,7 @@ func TestCmdAddTwoContainers(t *testing.T) {
 
 	setupRedirect = mockNsenterRedirect
 	testAnnotations[injectAnnotationKey] = "true"
-	testAnnotations[injectIstioKey] = "true"
+	testAnnotations[sidecarStatusKey] = "true"
 	testContainers = []string{"mockContainer", "mockContainer2"}
 
 	testCmdAdd(t)

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -220,7 +220,7 @@ func TestCmdAddTwoContainers(t *testing.T) {
 func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
 	defer resetGlobalTestVariables()
 
-	testAnnotations = nil
+	delete(testAnnotations, sidecarStatusKey)
 	testContainers = []string{"mockContainer", "mockContainer2"}
 	testCmdAdd(t)
 

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -48,14 +48,15 @@ const (
 
 var (
 	annotationRegistry = map[string]*annotationParam{
-		"inject":         {injectAnnotationKey, "", alwaysValidFunc},
-		"status":         {sidecarStatusKey, "", alwaysValidFunc},
-		"redirectMode":   {sidecarInterceptModeKey, defaultRedirectMode, validateInterceptionMode},
-		"ports":          {sidecarPortListKey, "", validatePortList},
-		"includeIPCidrs": {includeIPCidrsKey, defaultRedirectIPCidr, validateCIDRListWithWildcard},
-		"excludeIPCidrs": {excludeIPCidrsKey, defaultRedirectExcludeIPCidr, validateCIDRList},
-		"includePorts":   {includePortsKey, "", validatePortListWithWildcard},
-		"excludePorts":   {excludePortsKey, defaultRedirectExcludePort, validatePortList},
+		"inject":          {injectAnnotationKey, "", alwaysValidFunc},
+		"injectNoSidecar": {injectIstioKey, "", alwaysValidFunc},
+		"status":          {sidecarStatusKey, "", alwaysValidFunc},
+		"redirectMode":    {sidecarInterceptModeKey, defaultRedirectMode, validateInterceptionMode},
+		"ports":           {sidecarPortListKey, "", validatePortList},
+		"includeIPCidrs":  {includeIPCidrsKey, defaultRedirectIPCidr, validateCIDRListWithWildcard},
+		"excludeIPCidrs":  {excludeIPCidrsKey, defaultRedirectExcludeIPCidr, validateCIDRList},
+		"includePorts":    {includePortsKey, "", validatePortListWithWildcard},
+		"excludePorts":    {excludePortsKey, defaultRedirectExcludePort, validatePortList},
 	}
 )
 

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -43,20 +43,18 @@ const (
 
 	sidecarInterceptModeKey = "sidecar.istio.io/interceptionMode"
 	sidecarPortListKey      = "status.sidecar.istio.io/port"
-	sidecarStatusKey        = "sidecar.istio.io/status"
 )
 
 var (
 	annotationRegistry = map[string]*annotationParam{
-		"inject":          {injectAnnotationKey, "", alwaysValidFunc},
-		"injectNoSidecar": {injectIstioKey, "", alwaysValidFunc},
-		"status":          {sidecarStatusKey, "", alwaysValidFunc},
-		"redirectMode":    {sidecarInterceptModeKey, defaultRedirectMode, validateInterceptionMode},
-		"ports":           {sidecarPortListKey, "", validatePortList},
-		"includeIPCidrs":  {includeIPCidrsKey, defaultRedirectIPCidr, validateCIDRListWithWildcard},
-		"excludeIPCidrs":  {excludeIPCidrsKey, defaultRedirectExcludeIPCidr, validateCIDRList},
-		"includePorts":    {includePortsKey, "", validatePortListWithWildcard},
-		"excludePorts":    {excludePortsKey, defaultRedirectExcludePort, validatePortList},
+		"inject":         {injectAnnotationKey, "", alwaysValidFunc},
+		"status":         {sidecarStatusKey, "", alwaysValidFunc},
+		"redirectMode":   {sidecarInterceptModeKey, defaultRedirectMode, validateInterceptionMode},
+		"ports":          {sidecarPortListKey, "", validatePortList},
+		"includeIPCidrs": {includeIPCidrsKey, defaultRedirectIPCidr, validateCIDRListWithWildcard},
+		"excludeIPCidrs": {excludeIPCidrsKey, defaultRedirectExcludeIPCidr, validateCIDRList},
+		"includePorts":   {includePortsKey, "", validatePortListWithWildcard},
+		"excludePorts":   {excludePortsKey, defaultRedirectExcludePort, validatePortList},
 	}
 )
 


### PR DESCRIPTION
Hello,
We had a scenario in our cluster were a pod got IP Rules when it did not have the sidecar, to prevent this I have added a check to make sure that the pod has a status annotation, which will only be present if there is a sidecar.
Feedback Welcome!
Thank You
