### PR TITLE
Detect clobbering of istio-cni content in CNI conf file

### DIFF
--- a/deployments/kubernetes/install/scripts/install-cni.sh
+++ b/deployments/kubernetes/install/scripts/install-cni.sh
@@ -28,17 +28,26 @@ function rm_bin_files() {
 HOST_CNI_NET_DIR=${CNI_NET_DIR:-/etc/cni/net.d}
 MOUNTED_CNI_NET_DIR=${MOUNTED_CNI_NET_DIR:-/host/etc/cni/net.d}
 
+CNI_CONF_NAME_OVERRIDE=${CNI_CONF_NAME:-}
+
 # default to first file in `ls` output
+# if dir is empty, default to a filename that is not likely to be lexicographically first in the dir
 CNI_CONF_NAME=${CNI_CONF_NAME:-$(ls ${MOUNTED_CNI_NET_DIR} | head -n 1)}
-CNI_CONF_NAME=${CNI_CONF_NAME:-10-calico.conflist}
+CNI_CONF_NAME=${CNI_CONF_NAME:-YYY-istio-cni.conflist}
 KUBECFG_FILE_NAME=${KUBECFG_FILE_NAME:-ZZZ-istio-cni-kubeconfig}
 CFGCHECK_INTERVAL=${CFGCHECK_INTERVAL:-1}
 
 function check_install() {
   cfgfile_nm=$(ls ${MOUNTED_CNI_NET_DIR} | head -n 1)
   if [[ "${cfgfile_nm}" != "${CNI_CONF_NAME}" ]]; then
-    echo "ERROR: CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
-    exit 1  
+    if [[ "${CNI_CONF_NAME_OVERRIDE}" != "" ]]; then
+       # Install was run with overridden cni config file so don't error out on the preempt check.
+       # Likely the only use for this is testing this script.
+       echo "WARNING: Configured CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
+    else
+       echo "ERROR: CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
+       exit 1
+    fi
   fi
   if [ -e "${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}" ]; then
     istiocni_conf=$(cat ${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME} | jq '.plugins[]? | select(.type == "istio-cni")')

--- a/deployments/kubernetes/install/test/install_cni.go
+++ b/deployments/kubernetes/install/test/install_cni.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -123,7 +124,7 @@ func startDocker(testNum int, wd, tempCNIConfDir, tempCNIBinDir,
 	tempK8sSvcAcctDir string, t *testing.T) string {
 
 	dockerImage := env("HUB", "") + "/install-cni:" + env("TAG", "")
-	errFileName := tempCNIConfDir + "/docker_run_stderr"
+	errFileName := path.Dir(tempCNIConfDir) + "/docker_run_stderr"
 
 	// Build arguments list by picking whatever is necessary from the environment.
 	args := []string{"run", "-d",
@@ -193,7 +194,12 @@ func compareConfResult(testWorkRootDir, tempCNIConfDir, result, expected string,
 	} else {
 		tempFail := mktemp(testWorkRootDir, result+".fail.XXXX", t)
 		t.Errorf("FAIL: result doesn't match expected: %v v. %v", tempResult, expected)
-		cp(tempResult, tempFail, t)
+		cp(tempResult, tempFail+"/"+"failResult", t)
+		cmd := exec.Command("diff", tempResult, expected)
+		diffOutput, derr := cmd.Output()
+		if derr != nil {
+			t.Logf("Diff output:\n %s", diffOutput)
+		}
 		t.Fatalf("Check %v for diff contents", tempFail)
 	}
 }


### PR DESCRIPTION
Modify istio-cni-node daemonset's install-cni.sh to periodically check for
- removed istio-cni content from plugins list
- removal of CNI config file
- adding of CNI config file that supersedes the on with istio-cni content
  (lexicographically first file)

If found, exit the proc with error so k8s will restart the pod and the
istio-cni install logic will reapply the config.

Fixes: #82 