### PR TITLE
Updates the usage section based on 2 step install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,22 @@ removes the need for a privileged, `NET_ADMIN` container in the Istio users' app
 
 ## Usage
 
-A complete set of instructions on how to use and install the Istio CNI is available on the Istio documentation sites under the "Istio Install Istio with the Istio CNI plugin".  Only a summary is provided here.  The steps are:
+A complete set of instructions on how to use and install the Istio CNI is available on the Istio documentation site under [Install Istio with the Istio CNI plugin](https://preliminary.istio.io/docs/setup/kubernetes/install/cni/).  Only a summary is provided here.  The steps are:
 
-1. Install Kubernetes and kubelet in a manner that can support the CNI
+1. Install Kubernetes and `kubelet` in a manner that can support the CNI
 
 2. Install Kubernetes with the [ServiceAccount admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#serviceaccount) enabled
 
-3. Install the Istio CNI components
+3. Install the Istio CNI components. A specific example assuming locally built CNI images would be:
+```console
+$ CNI_HUB=docker.io/my_userid
+$ CNI_TAG=mytag
+# run from the ${GOPATH}/src/istio.io/cni dir (repo where istio/cni was cloned)
+$ helm template --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=debug  deployments/kubernetes/install/helm/istio-cni > istio-cni_install.yaml
+$ kubectl apply -f istio-cni_install.yaml
+```
 
-4. Create and apply Istio manifests with the Istio CNI plugin enabled using the --set istio_cni.enabled=true helm variable
+4. Create and apply Istio manifests with the Istio CNI plugin enabled using the `--set istio_cni.enabled=true` Helm variable
 
 For most Kubernetes environments the `istio-cni` [helm parameters' defaults](deployments/kubernetes/install/helm/istio-cni/values.yaml) will configure the Istio CNI plugin in a manner compatible with the Kubernetes installation.  Refer to
 the [Hosted Kubernetes Usage](#hosted-kubernetes-usage) section for Kubernetes environment specific procedures.
@@ -62,7 +69,7 @@ of hosted Kubernetes environments and whether `istio-cni` has been trialed in th
    1. `kubectl create clusterrolebinding cni-cluster-admin-binding --clusterrole=cluster-admin --user=istio-user@gmail.com`
       1. User `istio-user@gmail.com` is an admin user associated with the gcloud GKE cluster
 
-1. Create the Istio CNI manifests with this option `--set cniBinDir=/home/kubernetes/bin`
+1. Create the Istio CNI manifests with this Helm chart option `--set cniBinDir=/home/kubernetes/bin`
 
 #### IKS Setup
 

--- a/test/README.md
+++ b/test/README.md
@@ -131,7 +131,7 @@ To run any of the Istio e2e test follow these steps:
 
 1. Clone the Istio repo in your local environment.
 
-2. Install the CNI components as decribed in the Usage section: [Usage](../README.md#Usage). This might include building your own images and/or charts or pulling the images and charts from official repositories.
+2. Install the CNI components as described in the Usage section: [Usage](../README.md#Usage). This might include building your own images and/or charts or pulling the images and charts from official repositories.
 
 3. Step 2 includes setting appropriate Helm values.
 The HUB and TAG value can be overridden using the environement variables:

--- a/test/README.md
+++ b/test/README.md
@@ -123,36 +123,36 @@ with the istio/istio code base.  Both the istio/istio repo and the istio/cni rep
 that the CNI works properly.
 
 In order to run the e2e tests in a local environment confirm:
-
 1. That you can successfully run the desired Istio e2e tests in your local environment without the CNI enabled
 
 2. That your local environment supports the requirements for the CNI plugin
 
-To run the Istio e2e test first, clone the Istio repo in your local environment.  Then, there are two options to run the tests.
+To run any of the Istio e2e test follow these steps:
 
-1. Run the Istio make target  
-```console
-make e2e_simple_cni
-```
-This runs the `e2e_simple` with the latest nightly CNI image pushed to gcr.io/istio-release.  The HUB and TAG value can be overridden using the environement variables:
+1. Clone the Istio repo in your local environment.
+
+2. Install the CNI components as decribed on the main README or other sources. This might include building your own images and/or charts or pulling the images and charts from official repositories.
+
+3. Step 2 includes setting appropriate helm values.
+The HUB and TAG value can be overridden using the environement variables:
 ```console
 export ISTIO_CNI_HUB=yourhub
 export ISTIO_CNI_TAG=yourtag
 ```
-
-
-2. Run any of the Istio e2e targets after setting up a few environment variables:
+```console
+--set "excludeNamespaces={}"
+```
+4. Run any of the Istio e2e targets after setting up a few environment variables:
 ```console
 export ENABLE_ISTIO_CNI=true
 export E2E_ARGS=--kube_inject_configmap=istio-sidecar-injector
-export EXTRA_HELM_SETTINGS=--set istio-cni.excludeNamespaces={} --set istio-cni.tag=$YOUR_CNI_TAG --set istio-cni.hub=$YOUR_CNI_HUB
 ```
-The value for `EXTRA_HELM_SETTINGS` will depend on your specific environment.
 
 The tag `$YOUR_CNI_TAG` should be set to the `$TAG` value you used when you built your CNI image.
 The hub `$YOUR_CNI_HUB` should be set to the location you used when you built your CNI image.
 Istio in most cases runs the e2e tests in the `istio-system` namespace and therefore the `excludeNamespaces` must be set to `NULL`.
 The e2e tests normally use `istioctl` to inject the sidecar and it is necessary to use a `ConfigMap` without the `initContainers` section.
-Depending on your environment you may need to override other default settings.  Any additional override settings can be added via the `EXTRA_HELM_SETTINGS`
+Depending on your environment you may need to override other default settings.
 
 If the `tag` and `hub` is not set, the test will use the latest hub and tag values checked into the istio/cni repository.  The default `tag` and `hub` values are fine to use if you do not want to build your own CNI images.
+The CNI will not be uninstalled after the test is completed.

--- a/test/README.md
+++ b/test/README.md
@@ -131,9 +131,9 @@ To run any of the Istio e2e test follow these steps:
 
 1. Clone the Istio repo in your local environment.
 
-2. Install the CNI components as decribed on the main README or other sources. This might include building your own images and/or charts or pulling the images and charts from official repositories.
+2. Install the CNI components as decribed in the Usage section: [Usage](../README.md#Usage). This might include building your own images and/or charts or pulling the images and charts from official repositories.
 
-3. Step 2 includes setting appropriate helm values.
+3. Step 2 includes setting appropriate Helm values.
 The HUB and TAG value can be overridden using the environement variables:
 ```console
 export ISTIO_CNI_HUB=yourhub
@@ -142,6 +142,7 @@ export ISTIO_CNI_TAG=yourtag
 ```console
 --set "excludeNamespaces={}"
 ```
+
 4. Run any of the Istio e2e targets after setting up a few environment variables:
 ```console
 export ENABLE_ISTIO_CNI=true
@@ -155,4 +156,5 @@ The e2e tests normally use `istioctl` to inject the sidecar and it is necessary 
 Depending on your environment you may need to override other default settings.
 
 If the `tag` and `hub` is not set, the test will use the latest hub and tag values checked into the istio/cni repository.  The default `tag` and `hub` values are fine to use if you do not want to build your own CNI images.
-The CNI will not be uninstalled after the test is completed.
+
+**The CNI will not be uninstalled after the test is completed.**


### PR DESCRIPTION
This change updates the usage section now that the
CNI and Istio charts have been fully decoupled and
a 2 step install process is required. It also updates
the e2e test procedure that also changed due to the
2 step install.