### PR TITLE
Add environment variable for cni configuration location.

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -121,6 +121,8 @@ spec:
                 configMapKeyRef:
                   name: istio-cni-config
                   key: cni_network_config
+            - name: CNI_NET_DIR
+              value: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
In cases where the configuration is not in the default location the
changes the install script makes to existing cni config (such as calico)
point calico's "downstream" config to the wrong place. This should fix
that.