### PR TITLE
Incorporate IPv6 changes from istio/istio 11916

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
       ISTIO_HUB: docker.io/tiswanso
-      ISTIO_TAG: ipv6-13117
+      ISTIO_TAG: ipv6-13563
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
       CNI_ENABLE: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ e2e-dind-test: &e2e-dind-test
     - run:
         name: Run e2e test
         command: |
-          docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB=${ISTIO_HUB:-gcr.io/istio-release} -e TAG=${ISTIO_TAG:-master-latest-daily} -e ISTIO_REMOTE=${ISTIO_REMOTE} -e ISTIO_REMOTE_BRANCH=${ISTIO_REMOTE_BRANCH} -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
+          docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB=${ISTIO_HUB:-gcr.io/istio-release} -e TAG=${ISTIO_TAG:-master-latest-daily} -e ISTIO_REMOTE=${ISTIO_REMOTE} -e ISTIO_REMOTE_BRANCH=${ISTIO_REMOTE_BRANCH} -e CNI_ENABLE=${CNI_ENABLE:-true} -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
     - run:
         name: Display cluster status (2)
         when: always
@@ -264,11 +264,11 @@ jobs:
     environment:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
-      ISTIO_HUB: gcr.io/istio-release
-      ISTIO_TAG: master-latest-daily
+      ISTIO_HUB: docker.io/tiswanso
+      ISTIO_TAG: ipv6-13117
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
-      ENABLE_CNI: false
+      CNI_ENABLE: false
     <<: *e2e-dind-test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,8 +265,8 @@ jobs:
     environment:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
-      ISTIO_HUB: gcr.io/istio-release
-      ISTIO_TAG: master-latest-daily
+      ISTIO_HUB: tiswanso
+      ISTIO_TAG: ipv6-13985
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
       CNI_ENABLE: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,20 +38,9 @@ dind-setup: &dind-setup
 
 dind-display_cluster_state: &dind-display_cluster_state
   command: |
-    DIND_ROOT="$PWD"
-
-    kubectl="kubectl"
-    if [[ ${K8S_SRC:-} ]]; then
-      cd kubernetes
-      kubectl="cluster/kubectl.sh"
-    fi
-
-    apiserver_port="$( "${DIND_ROOT}/dind-cluster.sh" apiserver-port )"
-    "${DIND_ROOT}/build/portforward.sh" -wait "$apiserver_port"
-
-    "${kubectl}" "--server=:${apiserver_port}" version
-    "${kubectl}" "--server=:${apiserver_port}" get all --all-namespaces -o wide
-    "${kubectl}" "--server=:${apiserver_port}" get nodes
+    docker exec -t kube-master sh -c "kubectl version"
+    docker exec -t kube-master sh -c "kubectl get nodes"
+    docker exec -t kube-master sh -c "kubectl get all --all-namespaces -o wide"
 
 dind-dump_cluster: &dind-dump_cluster
   command: |
@@ -143,7 +132,7 @@ e2e-dind-test: &e2e-dind-test
     - run:
         name: Run e2e test
         command: |
-          docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB=${ISTIO_HUB:-gcr.io/istio-release} -e TAG=${ISTIO_TAG:-master-latest-daily} -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
+          docker run --name=istio-e2e --network=container:kube-master -t -e CNI_TAG=${CIRCLE_SHA1} -e CNI_HUB='docker.io/istio' -e HUB=${ISTIO_HUB:-gcr.io/istio-release} -e TAG=${ISTIO_TAG:-master-latest-daily} -e ISTIO_REMOTE=${ISTIO_REMOTE} -e ISTIO_REMOTE_BRANCH=${ISTIO_REMOTE_BRANCH} -e SKIP_CLEAN='1' e2e-runner:latest /go/run_e2e.sh
     - run:
         name: Display cluster status (2)
         when: always
@@ -264,10 +253,22 @@ jobs:
   e2e-dind:
     <<: *dind-defaults
     environment:
+      <<: *dind-env
+      ISTIO_BRANCH: master
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
+    <<: *e2e-dind-test
+
+  e2e-dind-ipv6:
+    <<: *dind-defaults
+    environment:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
       ISTIO_HUB: gcr.io/istio-release
       ISTIO_TAG: master-latest-daily
+      ISTIO_REMOTE: https://github.com/tiswanso/istio.git
+      ISTIO_REMOTE_BRANCH: simpletest_ipv6
+      ENABLE_CNI: false
     <<: *e2e-dind-test
 
 workflows:
@@ -281,12 +282,15 @@ workflows:
       - install-cni:
           requires:
             - build
-      - e2e-dind:
+      - e2e-dind-ipv6:
           requires:
             - build
-      - e2e-dind-istio1.1:
-          requires:
-            - build
+#      - e2e-dind:
+#          requires:
+#           - build
+#      - e2e-dind-istio1.1:
+#          requires:
+#            - build
 
   # Nightly test
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ e2e-dind-test: &e2e-dind-test
     - run:
         name: Start kubeadm in DinD (KDC)
         command: |
+          export IP_MODE=${IP_MODE:-ipv4}
           export DIND_PORT_FORWARDER_WAIT=1
           export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
           ./fixed/dind-cluster-v1.10.sh up
@@ -257,6 +258,7 @@ jobs:
     <<: *dind-defaults
     environment:
       <<: *dind-env
+      IP_MODE: ipv6
       ISTIO_BRANCH: master
       ISTIO_HUB: gcr.io/istio-release
       ISTIO_TAG: master-latest-daily

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
       ISTIO_TAG: ipv6-13117
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
-      CNI_ENABLE: true
+      CNI_ENABLE: false
     <<: *e2e-dind-test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ dind-env-ipv6: &dind-env-ipv6
   DOCKER_VERSION: "17.03.0-ce"
   CNI_PLUGIN: bridge
   IP_MODE: ipv6
+  DIND_ALLOW_AAAA_USE: 'true'
 
 # dind default setup
 dind-defaults: &dind-defaults
@@ -265,10 +266,10 @@ jobs:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
       ISTIO_HUB: docker.io/tiswanso
-      ISTIO_TAG: ipv6-13563
+      ISTIO_TAG: ipv6-13117
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
-      CNI_ENABLE: true
+      CNI_ENABLE: false
     <<: *e2e-dind-test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,11 +265,11 @@ jobs:
     environment:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
-      ISTIO_HUB: docker.io/tiswanso
-      ISTIO_TAG: ipv6-13117
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
-      CNI_ENABLE: false
+      CNI_ENABLE: true
     <<: *e2e-dind-test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
       ISTIO_TAG: ipv6-13117
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
-      CNI_ENABLE: false
+      CNI_ENABLE: true
     <<: *e2e-dind-test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
       ISTIO_TAG: ipv6-13563
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
-      CNI_ENABLE: false
+      CNI_ENABLE: true
     <<: *e2e-dind-test
 
 workflows:
@@ -285,12 +285,12 @@ workflows:
       - e2e-dind-ipv6:
           requires:
             - build
-#      - e2e-dind:
-#          requires:
-#           - build
-#      - e2e-dind-istio1.1:
-#          requires:
-#            - build
+      - e2e-dind:
+          requires:
+            - build
+      - e2e-dind-istio1.1:
+          requires:
+            - build
 
   # Nightly test
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ e2e-dind-test: &e2e-dind-test
           export IP_MODE=${IP_MODE:-ipv4}
           export DIND_PORT_FORWARDER_WAIT=1
           export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
-          ./fixed/dind-cluster-v1.10.sh up
+          ./fixed/dind-cluster-v1.12.sh up
     - run:
         name: Display cluster status (1)
         <<: *dind-display_cluster_state

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,13 @@ dind-env: &dind-env
   DOCKER_VERSION: "17.03.0-ce"
   CNI_PLUGIN: flannel
 
+dind-env-ipv6: &dind-env-ipv6
+  GOPATH: /go
+  SKIP_CLEANUP: true
+  DOCKER_VERSION: "17.03.0-ce"
+  CNI_PLUGIN: bridge
+  IP_MODE: ipv6
+
 # dind default setup
 dind-defaults: &dind-defaults
   docker:
@@ -257,8 +264,7 @@ jobs:
   e2e-dind:
     <<: *dind-defaults
     environment:
-      <<: *dind-env
-      IP_MODE: ipv6
+      <<: *dind-env-ipv6
       ISTIO_BRANCH: master
       ISTIO_HUB: gcr.io/istio-release
       ISTIO_TAG: master-latest-daily

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,8 +265,8 @@ jobs:
     environment:
       <<: *dind-env-ipv6
       ISTIO_BRANCH: master
-      ISTIO_HUB: tiswanso
-      ISTIO_TAG: ipv6-13985
+      ISTIO_HUB: gcr.io/istio-release
+      ISTIO_TAG: master-latest-daily
       ISTIO_REMOTE: https://github.com/tiswanso/istio.git
       ISTIO_REMOTE_BRANCH: simpletest_ipv6
       CNI_ENABLE: true

--- a/.circleci/run_e2e.sh
+++ b/.circleci/run_e2e.sh
@@ -2,7 +2,7 @@
 
 CNI_HUB=${CNI_HUB:-istio}
 CNI_TAG=${CNI_TAG:-$1}
-ENABLE_CNI=${ENABLE_CNI:-true}
+CNI_ENABLE=${CNI_ENABLE:-true}
 
 # Dockerfile copies the PR's istio/cni helm chart into /go/helm/istio-cni
 chartdir=/go/helm
@@ -20,7 +20,7 @@ kubectl version
 echo "k8s Nodes"
 kubectl get nodes
 
-if [[ "${ENABLE_CNI}" == "true" ]]; then
+if [[ "${CNI_ENABLE}" == "true" ]]; then
     # Install istio-cni prior to executing the Istio e2e test.  Now that the helm chart for istio/istio no longer
     # depends on the istio-cni chart, we need to explicitly do this as a prereq for installing Istio
     # (the e2e_simple test installs Istio).
@@ -28,7 +28,7 @@ if [[ "${ENABLE_CNI}" == "true" ]]; then
     kubectl apply -f istio-cni_install.yaml
 fi
 
-echo "k8s: All pods (CNI enabled: ${ENABLE_CNI})"
+echo "k8s: All pods (CNI enabled: ${CNI_ENABLE})"
 kubectl get pods --all-namespaces -o wide
 
 HUB=${HUB:-gcr.io/istio-release}
@@ -36,4 +36,4 @@ TAG=${TAG:-master-latest-daily}
 
 HUB=${HUB} TAG=${TAG} make istioctl
 
-HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=${ENABLE_CNI} E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector ${SKIP_CLEAN:+ --skip_cleanup}" make test/local/auth/e2e_simple
+HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=${CNI_ENABLE} E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector ${SKIP_CLEAN:+ --skip_cleanup}" make test/local/auth/e2e_simple

--- a/.circleci/run_e2e.sh
+++ b/.circleci/run_e2e.sh
@@ -2,21 +2,38 @@
 
 CNI_HUB=${CNI_HUB:-istio}
 CNI_TAG=${CNI_TAG:-$1}
+ENABLE_CNI=${ENABLE_CNI:-true}
 
 # Dockerfile copies the PR's istio/cni helm chart into /go/helm/istio-cni
 chartdir=/go/helm
 
 cd /go/src/istio.io/istio
+if [[ "${ISTIO_REMOTE}" != "" ]]; then
+    git remote add nonorigin ${ISTIO_REMOTE}
+    git fetch nonorigin
+    git checkout nonorigin/${ISTIO_REMOTE_BRANCH:-master}
+fi
 
-# Install istio-cni prior to executing the Istio e2e test.  Now that the helm chart for istio/istio no longer
-# depends on the istio-cni chart, we need to explicitly do this as a prereq for installing Istio
-# (the e2e_simple test installs Istio).
-helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
-kubectl apply -f istio-cni_install.yaml
+echo "k8s version"
+kubectl version
+
+echo "k8s Nodes"
+kubectl get nodes
+
+if [[ "${ENABLE_CNI}" == "true" ]]; then
+    # Install istio-cni prior to executing the Istio e2e test.  Now that the helm chart for istio/istio no longer
+    # depends on the istio-cni chart, we need to explicitly do this as a prereq for installing Istio
+    # (the e2e_simple test installs Istio).
+    helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
+    kubectl apply -f istio-cni_install.yaml
+fi
+
+echo "k8s: All pods (CNI enabled: ${ENABLE_CNI})"
+kubectl get pods --all-namespaces -o wide
 
 HUB=${HUB:-gcr.io/istio-release}
 TAG=${TAG:-master-latest-daily}
 
 HUB=${HUB} TAG=${TAG} make istioctl
 
-HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=true E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector ${SKIP_CLEAN:+ --skip_cleanup}" make test/local/auth/e2e_simple
+HUB=${HUB} TAG=${TAG} ENABLE_ISTIO_CNI=${ENABLE_CNI} E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector ${SKIP_CLEAN:+ --skip_cleanup}" make test/local/auth/e2e_simple

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -283,6 +283,30 @@ iptables -t nat -X ISTIO_REDIRECT 2>/dev/null
 iptables -t nat -F ISTIO_IN_REDIRECT 2>/dev/null
 iptables -t nat -X ISTIO_IN_REDIRECT 2>/dev/null
 
+# IPv6 cleanup
+# Remove the old chains, to generate new configs.
+ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND 2>/dev/null || true
+ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND 2>/dev/null || true
+ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT 2>/dev/null || true
+
+# Flush and delete the istio chains.
+ip6tables -t nat -F ISTIO_OUTPUT 2>/dev/null || true
+ip6tables -t nat -X ISTIO_OUTPUT 2>/dev/null || true
+ip6tables -t nat -F ISTIO_INBOUND 2>/dev/null || true
+ip6tables -t nat -X ISTIO_INBOUND 2>/dev/null || true
+ip6tables -t mangle -F ISTIO_INBOUND 2>/dev/null || true
+ip6tables -t mangle -X ISTIO_INBOUND 2>/dev/null || true
+ip6tables -t mangle -F ISTIO_DIVERT 2>/dev/null || true
+ip6tables -t mangle -X ISTIO_DIVERT 2>/dev/null || true
+ip6tables -t mangle -F ISTIO_TPROXY 2>/dev/null || true
+ip6tables -t mangle -X ISTIO_TPROXY 2>/dev/null || true
+
+# Must be last, the others refer to it
+ip6tables -t nat -F ISTIO_REDIRECT 2>/dev/null || true
+ip6tables -t nat -X ISTIO_REDIRECT 2>/dev/null|| true
+ip6tables -t nat -F ISTIO_IN_REDIRECT 2>/dev/null || true
+ip6tables -t nat -X ISTIO_IN_REDIRECT 2>/dev/null || true
+
 if [ "${1:-}" = "clean" ]; then
   echo "Only cleaning, no new rules added"
   exit 0
@@ -501,30 +525,7 @@ fi
 
 # If ENABLE_INBOUND_IPV6 is unset (default unset), restrict IPv6 traffic.
 set +o nounset
-if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
-  # Remove the old chains, to generate new configs.
-  ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND 2>/dev/null || true
-  ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND 2>/dev/null || true
-  ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT 2>/dev/null || true
-
-  # Flush and delete the istio chains.
-  ip6tables -t nat -F ISTIO_OUTPUT 2>/dev/null || true
-  ip6tables -t nat -X ISTIO_OUTPUT 2>/dev/null || true
-  ip6tables -t nat -F ISTIO_INBOUND 2>/dev/null || true
-  ip6tables -t nat -X ISTIO_INBOUND 2>/dev/null || true
-  ip6tables -t mangle -F ISTIO_INBOUND 2>/dev/null || true
-  ip6tables -t mangle -X ISTIO_INBOUND 2>/dev/null || true
-  ip6tables -t mangle -F ISTIO_DIVERT 2>/dev/null || true
-  ip6tables -t mangle -X ISTIO_DIVERT 2>/dev/null || true
-  ip6tables -t mangle -F ISTIO_TPROXY 2>/dev/null || true
-  ip6tables -t mangle -X ISTIO_TPROXY 2>/dev/null || true
-
-  # Must be last, the others refer to it
-  ip6tables -t nat -F ISTIO_REDIRECT 2>/dev/null || true
-  ip6tables -t nat -X ISTIO_REDIRECT 2>/dev/null|| true
-  ip6tables -t nat -F ISTIO_IN_REDIRECT 2>/dev/null || true
-  ip6tables -t nat -X ISTIO_IN_REDIRECT 2>/dev/null || true
-
+if [ -n "${ENABLE_INBOUND_IPV6}" ]; then  
   # Create a new chain for redirecting outbound traffic to the common Envoy port.
   # In both chains, '-j RETURN' bypasses Envoy and '-j ISTIO_REDIRECT'
   # redirects to Envoy.

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -223,9 +223,15 @@ fi
 # need to split them in different arrays one for ipv4 and one for ipv6
 # in order to not to fail
 pl='/*'
+#
+# Next two lines, read comma separated inclusion and exclusion lists into
+# arrays, so each element could be validated individually.
+#
+IFS=',' read -ra EXCLUDE <<< "$OUTBOUND_IP_RANGES_EXCLUDE"
+IFS=',' read -ra INCLUDE <<< "$OUTBOUND_IP_RANGES_INCLUDE"
 ipv6_ranges_exclude=()
 ipv4_ranges_exclude=()
-for range in "${OUTBOUND_IP_RANGES_EXCLUDE[@]}"; do
+for range in "${EXCLUDE[@]}"; do
     r=${range%$pl}
     if isValidIP "$r"; then
         if isIPv4 "$r"; then
@@ -242,7 +248,7 @@ if [ "${OUTBOUND_IP_RANGES_INCLUDE}" == "*" ]; then
    ipv6_ranges_include=("*")
    ipv4_ranges_include=("*")
 else 
-    for range in "${OUTBOUND_IP_RANGES_INCLUDE[@]}"; do
+    for range in "${INCLUDE[@]}"; do
         r=${range%$pl}
         if isValidIP "$r"; then
             if isIPv4 "$r"; then

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -46,6 +46,7 @@ function usage() {
   echo '  -x: Comma separated list of IP ranges in CIDR form to be excluded from redirection. Only applies when all '
   # shellcheck disable=SC2016
   echo '      outbound traffic (i.e. "*") is being redirected (default to $ISTIO_SERVICE_EXCLUDE_CIDR).'
+  echo '  -o: Comma separated list of outbound ports to be excluded from redirection to Envoy (optional).'
   echo '  -k: Comma separated list of virtual interfaces whose inbound traffic (from VM)'
   echo '      will be treated as outbound (optional)'
   echo '  -t: Unit testing, only functions are loaded and no other instructions are executed.'
@@ -70,7 +71,7 @@ function isValidIP() {
    fi
 }
 #
-# Function return true if argument is a valid ipv4 address
+# Function return true if agrument is a valid ipv4 address
 #
 function isIPv4() {
    local ipv4regexp="^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"
@@ -81,7 +82,7 @@ function isIPv4() {
   fi
 }
 #
-# Function return true if argument is a valid ipv6 address
+# Function return true if agrument is a valid ipv6 address
 #
 function isIPv6() {
   local ipv6section="^[0-9a-fA-F]{1,4}$"
@@ -147,9 +148,10 @@ INBOUND_PORTS_INCLUDE=${ISTIO_INBOUND_PORTS-}
 INBOUND_PORTS_EXCLUDE=${ISTIO_LOCAL_EXCLUDE_PORTS-}
 OUTBOUND_IP_RANGES_INCLUDE=${ISTIO_SERVICE_CIDR-}
 OUTBOUND_IP_RANGES_EXCLUDE=${ISTIO_SERVICE_EXCLUDE_CIDR-}
+OUTBOUND_PORTS_EXCLUDE=${ISTIO_LOCAL_OUTBOUND_PORTS_EXCLUDE-}
 KUBEVIRT_INTERFACES=
 
-while getopts ":p:u:g:m:b:d:i:x:k:h:t" opt; do
+while getopts ":p:u:g:m:b:d:o:i:x:k:h:t" opt; do
   case ${opt} in
     p)
       PROXY_PORT=${OPTARG}
@@ -174,6 +176,9 @@ while getopts ":p:u:g:m:b:d:i:x:k:h:t" opt; do
       ;;
     x)
       OUTBOUND_IP_RANGES_EXCLUDE=${OPTARG}
+      ;;
+    o)
+      OUTBOUND_PORTS_EXCLUDE=${OPTARG}
       ;;
     k)
       KUBEVIRT_INTERFACES=${OPTARG}
@@ -336,6 +341,7 @@ echo "INBOUND_PORTS_INCLUDE=${INBOUND_PORTS_INCLUDE}"
 echo "INBOUND_PORTS_EXCLUDE=${INBOUND_PORTS_EXCLUDE}"
 echo "OUTBOUND_IP_RANGES_INCLUDE=${OUTBOUND_IP_RANGES_INCLUDE}"
 echo "OUTBOUND_IP_RANGES_EXCLUDE=${OUTBOUND_IP_RANGES_EXCLUDE}"
+echo "OUTBOUND_PORTS_EXCLUDE=${OUTBOUND_PORTS_EXCLUDE}"
 echo "KUBEVIRT_INTERFACES=${KUBEVIRT_INTERFACES}"
 echo "ENABLE_INBOUND_IPV6=${ENABLE_INBOUND_IPV6}"
 echo
@@ -470,9 +476,19 @@ iptables -t nat -N ISTIO_OUTPUT
 # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
-# Redirect app calls to back itself via Envoy when using the service VIP or endpoint
-# address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+# Apply port based exclusions. Must be applied before connections back to self
+# are redirected.
+if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
+  for port in ${OUTBOUND_PORTS_EXCLUDE}; do
+    iptables -t nat -A ISTIO_OUTPUT -p tcp --dport "${port}" -j RETURN
+  done
+fi
+
+if [ -z "${DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK-}" ]; then
+  # Redirect app calls back to itself via Envoy when using the service VIP or endpoint
+  # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
+  iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+fi
 
 for uid in ${PROXY_UID}; do
   # Avoid infinite loops. Don't redirect Envoy traffic directly back to
@@ -525,7 +541,7 @@ fi
 
 # If ENABLE_INBOUND_IPV6 is unset (default unset), restrict IPv6 traffic.
 set +o nounset
-if [ -n "${ENABLE_INBOUND_IPV6}" ]; then  
+if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   # Create a new chain for redirecting outbound traffic to the common Envoy port.
   # In both chains, '-j RETURN' bypasses Envoy and '-j ISTIO_REDIRECT'
   # redirects to Envoy.
@@ -567,6 +583,14 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
   ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
+  # Apply port based exclusions. Must be applied before connections back to self
+  # are redirected.
+  if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
+    for port in ${OUTBOUND_PORTS_EXCLUDE}; do
+      ip6tables -t nat -A ISTIO_OUTPUT -p tcp --dport "${port}" -j RETURN
+    done
+  fi
+
   # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
   ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_REDIRECT
@@ -587,7 +611,7 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   # container-to-container traffic both of which explicitly use
   # localhost.
   ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
-
+  
   # Apply outbound IPv6 exclusions. Must be applied before inclusions.
   if [ ${#ipv6_ranges_exclude[@]} -gt 0 ]; then
     for cidr in "${ipv6_ranges_exclude[@]}"; do

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -328,6 +328,8 @@ set -x # echo on
 IPTABLES_WAIT=30
 # The iptables command path
 IPTABLES_CMD=`which iptables`
+IP4TABLES_CMD=${IPTABLES_CMD}
+IP6TABLES_CMD=`which ip6tables`
 
 # Make sure this function is placed after the iptables calls to cleanup
 # the existing redirection rules and before any iptables call to populate
@@ -349,6 +351,12 @@ function iptables {
         fi
     done
     set -o errexit
+}
+
+function ip6tables {
+    IPTABLES_CMD=${IP6TABLES_CMD}
+    iptables $@
+    IPTABLES_CMD=${IP4TABLES_CMD}
 }
 
 # Create a new chain for redirecting outbound traffic to the common Envoy port.

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -19,7 +19,7 @@
 # Initialization script responsible for setting up port forwarding for Istio sidecar.
 
 function usage() {
-  echo "${0} -p PORT -u UID -g GID [-m mode] [-b ports] [-d ports] [-i CIDR] [-x CIDR] [-h]"
+  echo "${0} -p PORT -u UID -g GID [-m mode] [-b ports] [-d ports] [-i CIDR] [-x CIDR] [-k interfaces] [-h]"
   echo ''
   # shellcheck disable=SC2016
   echo '  -p: Specify the envoy port to which redirect all TCP traffic (default $ENVOY_PORT = 15001)'
@@ -56,6 +56,7 @@ function usage() {
 
 function dump {
     iptables-save
+    ip6tables-save
 }
 
 trap dump EXIT
@@ -92,6 +93,13 @@ INBOUND_PORTS_EXCLUDE=${ISTIO_LOCAL_EXCLUDE_PORTS-}
 OUTBOUND_IP_RANGES_INCLUDE=${ISTIO_SERVICE_CIDR-}
 OUTBOUND_IP_RANGES_EXCLUDE=${ISTIO_SERVICE_EXCLUDE_CIDR-}
 KUBEVIRT_INTERFACES=
+
+POD_IP=$(hostname --ip-address)
+# Check if pod's ip is ipv4 or ipv6, in case of ipv6 set variable
+# to program ip6tables
+if [ "$POD_IP" != "${POD_IP#*:[0-9a-fA-F]}" ]; then
+  ENABLE_INBOUND_IPV6=$POD_IP
+fi
 
 while getopts ":p:u:g:m:b:d:i:x:k:h" opt; do
   case ${opt} in
@@ -203,6 +211,7 @@ echo "INBOUND_PORTS_EXCLUDE=${INBOUND_PORTS_EXCLUDE}"
 echo "OUTBOUND_IP_RANGES_INCLUDE=${OUTBOUND_IP_RANGES_INCLUDE}"
 echo "OUTBOUND_IP_RANGES_EXCLUDE=${OUTBOUND_IP_RANGES_EXCLUDE}"
 echo "KUBEVIRT_INTERFACES=${KUBEVIRT_INTERFACES}"
+echo "ENABLE_INBOUND_IPV6=${ENABLE_INBOUND_IPV6}"
 echo
 
 INBOUND_CAPTURE_PORT=${INBOUND_CAPTURE_PORT:-$PROXY_PORT}
@@ -381,10 +390,111 @@ fi
 
 # If ENABLE_INBOUND_IPV6 is unset (default unset), restrict IPv6 traffic.
 set +o nounset
-if [ -z "${ENABLE_INBOUND_IPV6}" ]; then
-  # Drop all inbound traffic except established connections.
+if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   # TODO: support receiving IPv6 traffic in the same way as IPv4.
+  # Allow all ipv6 traffic inbound and outboud, whitebox mode for now
+
+
+  # Remove the old chains, to generate new configs.
+  ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND 2>/dev/null || true
+  ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND 2>/dev/null || true
+  ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT 2>/dev/null || true
+
+  # Flush and delete the istio chains.
+  ip6tables -t nat -F ISTIO_OUTPUT 2>/dev/null || true
+  ip6tables -t nat -X ISTIO_OUTPUT 2>/dev/null || true
+  ip6tables -t nat -F ISTIO_INBOUND 2>/dev/null || true
+  ip6tables -t nat -X ISTIO_INBOUND 2>/dev/null || true
+  ip6tables -t mangle -F ISTIO_INBOUND 2>/dev/null || true
+  ip6tables -t mangle -X ISTIO_INBOUND 2>/dev/null || true
+  ip6tables -t mangle -F ISTIO_DIVERT 2>/dev/null || true
+  ip6tables -t mangle -X ISTIO_DIVERT 2>/dev/null || true
+  ip6tables -t mangle -F ISTIO_TPROXY 2>/dev/null || true
+  ip6tables -t mangle -X ISTIO_TPROXY 2>/dev/null || true
+
+  # Must be last, the others refer to it
+  ip6tables -t nat -F ISTIO_REDIRECT 2>/dev/null || true
+  ip6tables -t nat -X ISTIO_REDIRECT 2>/dev/null|| true
+  ip6tables -t nat -F ISTIO_IN_REDIRECT 2>/dev/null || true
+  ip6tables -t nat -X ISTIO_IN_REDIRECT 2>/dev/null || true
+
+  # Create a new chain for redirecting outbound traffic to the common Envoy port.
+  # In both chains, '-j RETURN' bypasses Envoy and '-j ISTIO_REDIRECT'
+  # redirects to Envoy.
+  ip6tables -t nat -N ISTIO_REDIRECT
+  ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-port "${PROXY_PORT}"
+
+  # Use this chain also for redirecting inbound traffic to the common Envoy port
+  # when not using TPROXY.
+  ip6tables -t nat -N ISTIO_IN_REDIRECT
+  ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-port "${INBOUND_CAPTURE_PORT}"
+
+  # Handling of inbound ports. Traffic will be redirected to Envoy, which will process and forward
+  # to the local service. If not set, no inbound port will be intercepted by istio iptables.
+  if [ -n "${INBOUND_PORTS_INCLUDE}" ]; then
+    table=nat
+    ip6tables -t ${table} -N ISTIO_INBOUND
+    ip6tables -t ${table} -A PREROUTING -p tcp -j ISTIO_INBOUND
+
+    if [ "${INBOUND_PORTS_INCLUDE}" == "*" ]; then
+        # Makes sure SSH is not redirected
+        ip6tables -t ${table} -A ISTIO_INBOUND -p tcp --dport 22 -j RETURN
+        # Apply any user-specified port exclusions.
+        if [ -n "${INBOUND_PORTS_EXCLUDE}" ]; then
+        for port in ${INBOUND_PORTS_EXCLUDE}; do
+            ip6tables -t ${table} -A ISTIO_INBOUND -p tcp --dport "${port}" -j RETURN
+        done
+        fi
+    else
+        # User has specified a non-empty list of ports to be redirected to Envoy.
+        for port in ${INBOUND_PORTS_INCLUDE}; do
+            ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport "${port}" -j ISTIO_IN_REDIRECT
+        done
+    fi
+  fi
+
+  # Create a new chain for selectively redirecting outbound packets to Envoy.
+  ip6tables -t nat -N ISTIO_OUTPUT
+
+  # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
+  ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+
+  # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
+  # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
+  ip6tables -t nat -A ISTIO_OUTPUT -o lo ! -d ::1/128 -j ISTIO_REDIRECT
+
+  for uid in ${PROXY_UID}; do
+    # Avoid infinite loops. Don't redirect Envoy traffic directly back to
+    # Envoy for non-loopback traffic.
+    ip6tables -t nat -A ISTIO_OUTPUT -m owner --uid-owner ${uid} -j RETURN
+  done
+
+  for gid in ${PROXY_GID}; do
+    # Avoid infinite loops. Don't redirect Envoy traffic directly back to
+    # Envoy for non-loopback traffic.
+    ip6tables -t nat -A ISTIO_OUTPUT -m owner --gid-owner ${gid} -j RETURN
+  done
+
+  # Skip redirection for Envoy-aware applications and
+  # container-to-container traffic both of which explicitly use
+  # localhost.
+  ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
+  
+  # Apply outbound IPv6 inclusions.
+  # TODO Need to figure out differentiation  between IPv4 and IPv6 ranges 
+  # for now process only "*"
+  if [ "${OUTBOUND_IP_RANGES_INCLUDE}" == "*" ]; then
+    # Wildcard specified. Redirect all remaining outbound traffic to Envoy.
+    ip6tables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
+  fi 
+
+  for internalInterface in ${KUBEVIRT_INTERFACES}; do
+      ip6tables -t nat -I PREROUTING 1 -i "${internalInterface}" -j RETURN
+  done
+else
+  # Drop all inbound traffic except established connections.
   ip6tables -F INPUT || true
   ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT || true
+  ip6tables -A INPUT -i lo -d ::1 -j ACCEPT || true
   ip6tables -A INPUT -j REJECT || true
 fi


### PR DESCRIPTION
Adds tests using circleCI KDC bringup in ipv6 mode and IPv6 e2e-simple testcase fixes in istio/istio#13753

- istio-iptables.sh changes are identical to istio/istio master with the addition of the ip6tables function to retry on failure to handle potential concurrent ip6tables locking on the same node.
