### PR TITLE
Add all CircleCI jobs as preconditions to Mergify success

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,11 @@
 pull_request_rules:
   - name: Automatic merge on CI success and review
     conditions:
+      - "status-success=ci/circleci: lint"
       - "status-success=ci/circleci: build"
+      - "status-success=ci/circleci: install-cni"
+      - "status-success=ci/circleci: e2e-dind"
+      - "status-success=ci/circleci: e2e-dind-istio1.1"
       - status-success=cla/google
       - "#approved-reviews-by>=1"
       - label!=do-not-merge


### PR DESCRIPTION
This prevents Mergify from merging a PR before all CircleCI jobs have succeeded.