### PR TITLE
Set priorityClassName on istio-cni-node

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -98,6 +98,7 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
+      priorityClassName: system-node-critical
       serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/14327

This fix works for k8s v1.10+, cf. [Guaranteed Scheduling For Critical Add-On Pods](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical).
This is a partial fix for https://github.com/istio/istio/issues/14327 to only prevent race conditions with normal pods, by guaranteeing that the `istio-cni-node` pods [always start first on the nodes](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#effect-of-pod-priority-on-scheduling-order). There is still a race-condition with other CNI plugins on the node, e.g. Calico, which runs with the same priority.