### PR TITLE
Update to apps/v1

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -60,7 +60,7 @@ data:
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: istio-cni-node
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
These are using deprecated APIs that will be removed in k8s 1.16, which will release the same time we release istio 1.3

See istio/istio/issues/12211