### PR TITLE
Make use of RBAC v1

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -5,7 +5,7 @@
 
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-cni
 rules:
@@ -18,7 +18,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istio-cni


### PR DESCRIPTION
This PR changes the RBAC API version to the current v1 (which is GA since I think 1.8: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#auth).