### PR TITLE
Update Helm version to magic tag to enable rewrite during release

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/Chart.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: istio-cni
-version: 0.1.0
-appVersion: 0.1.0
-tillerVersion: ">=2.7.2-0"
+version: 1.1.0
+appVersion: 1.1.0
+tillerVersion: ">=2.7.2"
 description: Helm chart for istio-cni components
 keywords:
   - istio-cni


### PR DESCRIPTION
The release script rewrites the version and appVersion in
Chart.yaml but only when the current values are "1.1.0":
https://github.com/istio/istio/blob/37f66ed43167ae05b9889866f029bb5f33c92403/release/gcb/gcb_lib.sh#L188-L189

Updating the istio/cni Chart.yaml to use those magic values.