### PR TITLE
Place istio/cni on the BUILD_WITH_CONTAINER=1 plan

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# this repo is not yet on the container plan by default
-BUILD_WITH_CONTAINER ?= 0
+# this repo is on the container plan by default
+BUILD_WITH_CONTAINER ?= 1


### PR DESCRIPTION
Currently prow-e2e doesn't work well with BUILD_WITH_CONTAINER=1
however, we are very close to having all make targts work with
BUILD_WITH_CONTAINER=1.