### PR TITLE
Enable `make e2e`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	$(CONTAINER_OPTIONS) \
 	--mount type=bind,source="$(PWD)",destination="/work" \
 	--mount type=bind,source="$(TARGET_OUT)",destination="/targetout" \
+	--mount type=bind,source="/sys/fs/cgroup",destination="/sys/fs/cgroup" \
+	--mount type=bind,source="/lib/modules",destination="/lib/modules",readonly \
 	--mount type=volume,source=home,destination="/home" \
 	-w /work $(IMG)
 else

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -177,7 +177,7 @@ $(ISTIO_OUT) $(ISTIO_BIN):
 #-----------------------------------------------------------------------------
 # Target: precommit
 #-----------------------------------------------------------------------------
-prow-e2e:
+e2e:
 # Needed as the volume mount /home in the container is mounted as UID 0.
 # Kind needs to write to /home, so we chown it to our UID.
 ifeq ($(IN_BUILD_CONTAINER),1)

--- a/common/scripts/init_docker.sh
+++ b/common/scripts/init_docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# WARNING: DO NOT EDIT, THIS FILE IS PROBABLY A COPY
+#
+# The original version of this file is located in the https://github.com/istio/common-files repo.
+# If you're looking at this file in a different repo and want to make a change, please go to the
+# common-files repo, make the change there and check it in. Then come back to this repo and run
+# "make update-common".
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script starts dockerd and waits or it to start
+# The usage of this script is meant for DIND or docker specific targets
+
+daemon -U -- dockerd
+echo "Waiting for dockerd to start..."
+while :
+do
+	echo "Checking for running docker daemon."
+	if [[ $(docker info > /dev/null 2>&1) -eq 0 ]]; then
+		echo "The docker daemon is running."
+		break
+	fi
+	sleep 1
+done

--- a/test/prow-e2e.sh
+++ b/test/prow-e2e.sh
@@ -40,7 +40,7 @@ function setup_kind_cluster() {
 
   KUBECONFIG="$(kind get kubeconfig-path --name="istio-testing")"
   export KUBECONFIG
-  kind get kubeconfig --internal --name="istio-testing" > $KUBECONFIG
+  kind get kubeconfig --internal --name="istio-testing" > "${KUBECONFIG}"
   kubectl cluster-info
 }
 
@@ -66,7 +66,7 @@ if [[ ! -d "${ISTIO_DIR}" ]]
 then
     git clone https://github.com/istio/istio.git "${ISTIO_DIR}"
 fi
-pushd ${ISTIO_DIR} || exit
+pushd "${ISTIO_DIR}" || exit
   make istioctl
 
   HUB=gcr.io/istio-release TAG=master-latest-daily ENABLE_ISTIO_CNI=true E2E_ARGS="--kube_inject_configmap=istio-sidecar-injector" make test/local/auth/e2e_simple


### PR DESCRIPTION
make prow-e2e works in prow, but not locally. This PR enables
e2e to work locally.