### PR TITLE
Make `test` work properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ RUN = $(CONTAINER_CLI) run --net=host -t -i --sig-proxy=true -u $(UID):docker --
 	--mount type=bind,source="$(PWD)",destination="/work" \
 	--mount type=bind,source="$(TARGET_OUT)",destination="/targetout" \
 	--mount type=volume,source=home,destination="/home" \
+	--mount type=bind,source=/tmp,destination=/tmp \
 	-w /work $(IMG)
 else
 $(info Building with your local toolchain.)

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -244,7 +244,7 @@ include tools/istio-cni-docker.mk
 #-----------------------------------------------------------------------------
 # Target: test
 #-----------------------------------------------------------------------------
-.PHONY: test-cni
+.PHONY: test
 
 JUNIT_REPORT := $(shell which go-junit-report 2> /dev/null || echo "${ISTIO_BIN}/go-junit-report")
 
@@ -255,15 +255,12 @@ ${ISTIO_BIN}/go-junit-report:
 # Run coverage tests
 JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit-tests.xml
 ifeq ($(WHAT),)
-       TEST_OBJ = install-test cmd-test
+       TEST_OBJ = docker install-test cmd-test
 else
        TEST_OBJ = selected-pkg-test
 endif
 
-/var/run/secrets/kubernetes.io/serviceaccount/token:
-	echo "dummy-token" > /var/run/secrets/kubernetes.io/serviceaccount/token
-
-test-cni: /var/run/secrets/kubernetes.io/serviceaccount/token | $(JUNIT_REPORT)
+test: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; unset GOOS && unset GOARCH && CGO_ENABLED=1 && \
 	$(MAKE) -f Makefile.core.mk --keep-going $(TEST_OBJ) \


### PR DESCRIPTION
Sadly a host mount must be used to share files between the build container
and the test case. The test case uses /tmp for this. This test case will
spew a bunch of backtraces, which it is supposed to spew.  The actual
test results pass.