### PR TITLE
Allow to set custom annotations on pod level

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -85,9 +85,9 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-{{- range $key, $value := .Values.cniCustomPodAnnotations }}
-        {{ $key }}: {{ $value | quote }}
-{{- end }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -85,6 +85,9 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
+{{- range $key, $value := .Values.cniCustomPodAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+{{- end }}
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/deployments/kubernetes/install/helm/istio-cni/values.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values.yaml
@@ -18,6 +18,9 @@ cniConfFileName: ""
 excludeNamespaces:
   - istio-system
 
+# Custom annotations on pod level, if you need them
+podAnnotations: {}
+
 # If this value is set a RoleBinding will be created
 # in the same namespace as the istio-cni DaemonSet is created.
 # This can be used to bind a preexisting ClusterRole to the istio/cni ServiceAccount

--- a/deployments/kubernetes/install/helm/istio-cni/values_gke.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values_gke.yaml
@@ -16,3 +16,7 @@ cniConfDir: /etc/cni/net.d
 
 excludeNamespaces:
   - istio-system
+
+# Custom annotations on pod level, if you need them
+podAnnotations: {}
+


### PR DESCRIPTION
This PR allows to add custom annotations on the Pod level for the DaemonSet. This is beneficial to support use cases where for example custom validators or operators utilize annotations to  check if something should be allowed or not.
As a concrete example, we would like to be able to document that the pods as exceptionally getting broader access rights.