### PR TITLE
Lower priorityClassName on istio-cni-node

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -98,7 +98,7 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: istio-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/14327

This is a partial fix for https://github.com/istio/istio/issues/14327 to make sure istio-cni has a relatively lower pod priority than the "real" CNI while still having a relatively higher priority than the other pods. This mitigates the situation that istio-cni starts before CNI plugins and modify the CNI configuration file in a contentious way.