### PR TITLE
Fix TestCmdAddExcludePodWithIstioInitContainer unit test

### DIFF
--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -255,6 +255,7 @@ func TestCmdAddExcludePod(t *testing.T) {
 func TestCmdAddExcludePodWithIstioInitContainer(t *testing.T) {
 	defer resetGlobalTestVariables()
 
+	k8Args = "K8S_POD_NAMESPACE=testNS;K8S_POD_NAME=testPodName"
 	testContainers = []string{"mockContainer"}
 	testInitContainers = map[string]struct{}{
 		"foo-init":   {},


### PR DESCRIPTION
Set correct namespace in mock so that istio-init check is exercised

Issue: https://github.com/istio/istio/issues/18021