### PR TITLE
Watch-based repair controller

### DIFF
--- a/cmd/istio-cni-repair/main.go
+++ b/cmd/istio-cni-repair/main.go
@@ -137,15 +137,15 @@ func logCurrentOptions(bpr *repair.BrokenPodReconciler, options *ControllerOptio
 	if options.RunAsDaemon {
 		log.Infof("Controller Option: Running as a Daemon.")
 	}
-	if bpr.Options.LabelPods {
+	if bpr.Options.DeletePods {
+		log.Info("Controller Option: Deleting broken pods. Pod Labeling deactivated.")
+	}
+	if bpr.Options.LabelPods && !bpr.Options.DeletePods {
 		log.Infof(
 			"Controller Option: Labeling broken pods with label %s=%s",
 			bpr.Options.PodLabelKey,
 			bpr.Options.PodLabelValue,
 		)
-	}
-	if bpr.Options.DeletePods {
-		log.Info("Controller Option: Deleting broken pods")
 	}
 	if bpr.Filters.SidecarAnnotation != "" {
 		log.Infof("Filter option: Only managing pods with an annotation with key %s", bpr.Filters.SidecarAnnotation)

--- a/cmd/istio-cni-repair/main.go
+++ b/cmd/istio-cni-repair/main.go
@@ -225,7 +225,7 @@ func main() {
 			log.Fatalf("Fatal error constructing repair controller: %+v", err)
 		}
 		stopCh := make(chan struct{})
-		rc.Run(1, stopCh)
+		rc.Run(stopCh)
 
 	} else {
 		err := reconcile(podFixer)

--- a/cmd/istio-cni-repair/main.go
+++ b/cmd/istio-cni-repair/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.uber.org/multierr"
 	client "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/clientcmd"
@@ -31,12 +32,8 @@ import (
 )
 
 type ControllerOptions struct {
-	DaemonPollPeriod int             `json:"daemon_poll_period"`
-	RepairOptions    *repair.Options `json:"repair_options"`
-	DeletePods       bool            `json:"delete_pods"`
-	LabelPods        bool            `json:"label_pods"`
-	CreateEvents     bool            `json:"create_events"`
-	RunAsDaemon      bool            `json:"run_as_daemon"`
+	RepairOptions *repair.Options `json:"repair_options"`
+	RunAsDaemon   bool            `json:"run_as_daemon"`
 }
 
 var (
@@ -72,9 +69,7 @@ func parseFlags() (filters *repair.Filters, options *ControllerOptions) {
 	// Repair Options
 	pflag.Bool("delete-pods", false, "Controller will delete pods")
 	pflag.Bool("label-pods", false, "Controller will label pods")
-	pflag.Bool("create-events", true, "Controller will create Kubernetes events")
 	pflag.Bool("run-as-daemon", false, "Controller will run in a loop")
-	pflag.Int("daemon-poll-period", 10, "Polling period for daemon (in seconds)")
 	pflag.String(
 		"broken-pod-label-key",
 		"cni.istio.io/uninitialized",
@@ -108,15 +103,10 @@ func parseFlags() (filters *repair.Filters, options *ControllerOptions) {
 		LabelSelectors:                  viper.GetString("label-selectors"),
 	}
 	options = &ControllerOptions{
-		DeletePods:       viper.GetBool("delete-pods"),
-		RunAsDaemon:      viper.GetBool("run-as-daemon"),
-		DaemonPollPeriod: viper.GetInt("daemon-poll-period"),
-		LabelPods:        viper.GetBool("label-pods"),
-		CreateEvents:     viper.GetBool("create-events"),
+		RunAsDaemon: viper.GetBool("run-as-daemon"),
 		RepairOptions: &repair.Options{
 			DeletePods:    viper.GetBool("delete-pods"),
 			LabelPods:     viper.GetBool("label-pods"),
-			CreateEvents:  viper.GetBool("create-events"),
 			PodLabelKey:   viper.GetString("broken-pod-label-key"),
 			PodLabelValue: viper.GetString("broken-pod-label-value"),
 		},
@@ -145,22 +135,18 @@ func clientSetup() (clientset *client.Clientset, err error) {
 // Log human-readable output describing the current filter and option selection
 func logCurrentOptions(bpr *repair.BrokenPodReconciler, options *ControllerOptions) {
 	if options.RunAsDaemon {
-		log.Infof("Controller Option: Running as a Daemon; will sleep %d seconds between passes", options.DaemonPollPeriod)
+		log.Infof("Controller Option: Running as a Daemon.")
 	}
-	if options.LabelPods {
+	if bpr.Options.LabelPods {
 		log.Infof(
 			"Controller Option: Labeling broken pods with label %s=%s",
 			bpr.Options.PodLabelKey,
 			bpr.Options.PodLabelValue,
 		)
 	}
-	if options.DeletePods {
+	if bpr.Options.DeletePods {
 		log.Info("Controller Option: Deleting broken pods")
 	}
-	if options.CreateEvents {
-		log.Info("Controller option: Creating Kubernetes Events for broken pods")
-	}
-
 	if bpr.Filters.SidecarAnnotation != "" {
 		log.Infof("Filter option: Only managing pods with an annotation with key %s", bpr.Filters.SidecarAnnotation)
 	}
@@ -190,8 +176,6 @@ func main() {
 
 	filters, options := parseFlags()
 
-	// TODO:(stewartbutler) This should probably use client-go/tools/cache at some
-	//  point, but I'm not sure yet if it is needed.
 	clientSet, err := clientSetup()
 	if err != nil {
 		log.Fatalf("Could not construct clientSet: %s", err)
@@ -199,25 +183,6 @@ func main() {
 
 	podFixer := repair.NewBrokenPodReconciler(clientSet, filters, options.RepairOptions)
 	logCurrentOptions(&podFixer, options)
-
-	reconcile := func(bpr repair.BrokenPodReconciler) error {
-		if options.CreateEvents {
-			if err := bpr.CreateEventsForBrokenPods(); err != nil {
-				return err
-			}
-		}
-		if options.LabelPods {
-			if err := bpr.LabelBrokenPods(); err != nil {
-				return err
-			}
-		}
-		if options.DeletePods {
-			if err := bpr.DeleteBrokenPods(); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 
 	if options.RunAsDaemon {
 		rc, err := repair.NewRepairController(podFixer)
@@ -228,7 +193,13 @@ func main() {
 		rc.Run(stopCh)
 
 	} else {
-		err := reconcile(podFixer)
+		err = nil
+		if podFixer.Options.LabelPods {
+			err = multierr.Append(err, podFixer.LabelBrokenPods())
+		}
+		if podFixer.Options.DeletePods {
+			err = multierr.Append(err, podFixer.DeleteBrokenPods())
+		}
 		if err != nil {
 			log.Fatalf(err.Error())
 		}

--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -141,7 +141,7 @@ spec:
             path: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
 ---
 {{- if .Values.repair.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-cni-repair

--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -131,60 +131,18 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-      volumes:
-        # Used to install CNI.
-        - name: cni-bin-dir
-          hostPath:
-            path: {{ default "/opt/cni/bin" .Values.cniBinDir }}
-        - name: cni-net-dir
-          hostPath:
-            path: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
----
 {{- if .Values.repair.enabled }}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istio-cni-repair
-  namespace: {{ .Release.Namespace }}
-  labels:
-    k8s-app: istio-cni-repair
-    {{- template "common_labels" . }}
-spec:
-  selector:
-    matchLabels:
-      k8s-app: istio-cni-repair
-  template:
-    metadata:
-      labels:
-        k8s-app: istio-cni-repair
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-    spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      tolerations:
-      # Make sure istio-cni-node gets scheduled on all nodes.
-      - effect: NoSchedule
-        operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
-      priorityClassName: system-cluster-critical
-      serviceAccountName: istio-cni
-      containers:
-      # This container repairs broken CNI pods
-      - name: repair-controller
-        image: {{ .Values.repair.hub }}/install-cni:{{ .Values.repair.tag }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        command:
-        - /opt/cni/bin/istio-cni-repair
-        env:
+        # This container repairs broken CNI pods
+        - name: repair-cni
+          image: {{ .Values.repair.hub }}/install-cni:{{ .Values.repair.tag }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          command:
+          - /opt/cni/bin/istio-cni-repair
+          env:
+          - name: "REPAIR_NODE-NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: "REPAIR_LABEL-PODS"
             value: "{{.Values.repair.labelPods}}"
           # Set to true to enable pod deletion
@@ -200,11 +158,15 @@ spec:
             value: "{{.Values.repair.brokenPodLabelKey}}"
           - name: "REPAIR_BROKEN-POD-LABEL-VALUE"
             value: "{{.Values.repair.brokenPodLabelValue}}"
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 30
 {{- end }}
-
+      volumes:
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: {{ default "/opt/cni/bin" .Values.cniBinDir }}
+        - name: cni-net-dir
+          hostPath:
+            path: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
 ---
 
 apiVersion: v1

--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -131,22 +131,62 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+      volumes:
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: {{ default "/opt/cni/bin" .Values.cniBinDir }}
+        - name: cni-net-dir
+          hostPath:
+            path: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
+---
 {{- if .Values.repair.enabled }}
-        # This container repairs broken CNI pods
-        - name: repair-cni
-          image: {{ .Values.repair.hub }}/install-cni:{{ .Values.repair.tag }}
-          imagePullPolicy: {{ .Values.pullPolicy }}
-          command:
-          - /opt/cni/bin/istio-cni-repair
-          env:
-          - name: "REPAIR_NODE-NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-cni-repair
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: istio-cni-repair
+    {{- template "common_labels" . }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: istio-cni-repair
+  template:
+    metadata:
+      labels:
+        k8s-app: istio-cni-repair
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+      # Make sure istio-cni-node gets scheduled on all nodes.
+      - effect: NoSchedule
+        operator: Exists
+      # Mark the pod as a critical add-on for rescheduling.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      priorityClassName: system-cluster-critical
+      serviceAccountName: istio-cni
+      containers:
+      # This container repairs broken CNI pods
+      - name: repair-controller
+        image: {{ .Values.repair.hub }}/install-cni:{{ .Values.repair.tag }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+        - /opt/cni/bin/istio-cni-repair
+        env:
           - name: "REPAIR_LABEL-PODS"
             value: "{{.Values.repair.labelPods}}"
-          - name: "REPAIR_CREATE-EVENTS"
-            value: "{{.Values.repair.createEvents}}"
           # Set to true to enable pod deletion
           - name: "REPAIR_DELETE-PODS"
             value: "{{.Values.repair.deletePods}}"
@@ -160,15 +200,11 @@ spec:
             value: "{{.Values.repair.brokenPodLabelKey}}"
           - name: "REPAIR_BROKEN-POD-LABEL-VALUE"
             value: "{{.Values.repair.brokenPodLabelValue}}"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
 {{- end }}
-      volumes:
-        # Used to install CNI.
-        - name: cni-bin-dir
-          hostPath:
-            path: {{ default "/opt/cni/bin" .Values.cniBinDir }}
-        - name: cni-net-dir
-          hostPath:
-            path: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
+
 ---
 
 apiVersion: v1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
-    go.uber.org/multierr v1.1.0
+	go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.10.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/containernetworking/cni v0.7.0-alpha1
 	github.com/containernetworking/plugins v0.7.3
-	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
+    go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.10.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/repair/repair.go
+++ b/pkg/repair/repair.go
@@ -64,13 +64,10 @@ func NewBrokenPodReconciler(client client.Interface, filters *Filters, options *
 func (bpr BrokenPodReconciler) ReconcilePod(pod v1.Pod) (err error) {
 	log.Debugf("Reconciling pod %s", pod.Name)
 
-	if bpr.Options.LabelPods {
-		err = multierr.Append(err, bpr.labelBrokenPod(pod))
-
-	}
-
 	if bpr.Options.DeletePods {
 		err = multierr.Append(err, bpr.deleteBrokenPod(pod))
+	} else if bpr.Options.LabelPods {
+		err = multierr.Append(err, bpr.labelBrokenPod(pod))
 	}
 
 	return err

--- a/pkg/repair/repair_test.go
+++ b/pkg/repair/repair_test.go
@@ -20,11 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -562,63 +560,6 @@ func TestBrokenPodReconciler_deleteBrokenPods(t *testing.T) {
 				t.Errorf("DeleteBrokenPods() error havePods = %v, wantPods = %v", havePods.Items, tt.wantPods)
 			}
 
-		})
-	}
-}
-
-func TestBrokenPodReconciler_ListEvents(t *testing.T) {
-	type fields struct {
-		client  kubernetes.Interface
-		Filters *Filters
-		Options *Options
-	}
-	tests := []struct {
-		name     string
-		fields   fields
-		wantList map[types.UID]v1.Event
-		wantErr  bool
-	}{
-		{
-			name: "No matching Events",
-			fields: fields{
-				client: fake.NewSimpleClientset(
-					&brokenPodWaiting,
-					irrelevantEvent,
-				),
-				Filters: &Filters{},
-				Options: &Options{},
-			},
-			wantList: map[types.UID]v1.Event{},
-			wantErr:  false,
-		},
-		{
-			name: "One matching Events",
-			fields: fields{
-				client: fake.NewSimpleClientset(
-					relevantEvent,
-				),
-				Filters: &Filters{},
-				Options: &Options{},
-			},
-			wantList: map[types.UID]v1.Event{relevantEventUID: *relevantEvent},
-			wantErr:  false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bpr := BrokenPodReconciler{
-				client:  tt.fields.client,
-				Filters: tt.fields.Filters,
-				Options: tt.fields.Options,
-			}
-			gotList, err := bpr.ListEvents()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ListEvents() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(gotList, tt.wantList) {
-				t.Errorf("ListEvents() gotList = %v, want %v", spew.Sdump(gotList), spew.Sdump(tt.wantList))
-			}
 		})
 	}
 }

--- a/pkg/repair/repair_test_helpers.go
+++ b/pkg/repair/repair_test_helpers.go
@@ -17,7 +17,6 @@ package repair
 import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type makePodArgs struct {
@@ -74,62 +73,6 @@ func makePod(args makePodArgs) *v1.Pod {
 	}
 	return pod
 }
-
-func makeEvent(args makeEventArgs) *v1.Event {
-	return &v1.Event{
-		ObjectMeta: v12.ObjectMeta{
-			GenerateName: args.Name,
-			Namespace:    args.Namespace,
-			UID:          args.UID,
-			Labels:       args.Labels,
-		},
-		InvolvedObject: *args.Object,
-		Reason:         args.Reason,
-		Message:        args.Message,
-		Type:           args.EventType,
-	}
-}
-
-type makeEventArgs struct {
-	Name      string
-	Namespace string
-	UID       types.UID
-	Labels    map[string]string
-	Reason    string
-	Message   string
-	EventType string
-	Object    *v1.ObjectReference
-}
-
-var (
-	irrelevantEvent = makeEvent(
-		makeEventArgs{
-			Name:      "Test",
-			Namespace: "TestNS",
-			UID:       types.UID(1234),
-			Labels: map[string]string{
-				"testlabel": "true",
-			},
-			Reason:    "Test",
-			Message:   "This is a test event",
-			EventType: "Warning",
-			Object:    &v1.ObjectReference{},
-		})
-	relevantEventUID = types.UID(4567)
-	relevantEvent    = makeEvent(
-		makeEventArgs{
-			Name:      "Test2",
-			Namespace: "TestNS",
-			UID:       types.UID(2345),
-			Labels: map[string]string{
-				"istio-cni-daemonset-event": "true",
-			},
-			Reason:    "Test",
-			Message:   "This is a test event",
-			EventType: "Warning",
-			Object:    &v1.ObjectReference{UID: relevantEventUID},
-		})
-)
 
 // Container specs
 var (

--- a/pkg/repair/repaircontroller.go
+++ b/pkg/repair/repaircontroller.go
@@ -1,0 +1,124 @@
+package repair
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"istio.io/pkg/log"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+type RepairController struct {
+	clientset     client.Interface
+	workQueue     workqueue.RateLimitingInterface
+	podController cache.Controller
+
+	reconciler BrokenPodReconciler
+}
+
+func NewRepairController(reconciler BrokenPodReconciler) (*RepairController, error) {
+	c := &RepairController{
+		clientset:  reconciler.client,
+		workQueue:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		reconciler: reconciler,
+	}
+
+	podListWatch := cache.NewFilteredListWatchFromClient(
+		c.clientset.CoreV1().RESTClient(),
+		"pods",
+		metav1.NamespaceAll,
+		func(options *metav1.ListOptions) {
+			labelSelectors := []string{}
+			fieldSelectors := []string{}
+
+			for _, ls := range []string{options.LabelSelector, reconciler.Filters.LabelSelectors} {
+				if ls != "" {
+					labelSelectors = append(labelSelectors, ls)
+				}
+			}
+			for _, fs := range []string{options.FieldSelector, reconciler.Filters.LabelSelectors} {
+				if fs != "" {
+					fieldSelectors = append(fieldSelectors, fs)
+				}
+			}
+			options.LabelSelector = strings.Join(labelSelectors, ",")
+			options.FieldSelector = strings.Join(fieldSelectors, ",")
+		},
+	)
+
+	_, c.podController = cache.NewInformer(podListWatch, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(newObj interface{}) {
+			c.workQueue.AddRateLimited(newObj)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			c.workQueue.AddRateLimited(newObj)
+		},
+	})
+
+	return c, nil
+}
+
+func (rc *RepairController) Run(threadiness int, stopCh <-chan struct{}) {
+	go rc.podController.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, rc.podController.HasSynced) {
+		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		return
+	}
+
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(
+			func() {
+				for rc.processNextItem() {
+				}
+			}, time.Second,
+			stopCh,
+		)
+	}
+
+	<-stopCh
+	log.Infof("Stopping repair controller.")
+}
+
+func (rc *RepairController) processNextItem() bool {
+	obj, quit := rc.workQueue.Get()
+	if quit {
+		return false
+	}
+	defer rc.workQueue.Done(obj)
+
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		log.Errorf("Error decoding object, invalid type")
+		if rc.workQueue.NumRequeues(obj) < 5 {
+			log.Infof("Requeueing failed object...")
+			rc.workQueue.AddRateLimited(obj)
+		}
+		return true
+	}
+
+	err := rc.reconciler.ReconcilePod(*pod)
+
+	if err == nil {
+		log.Debugf("Removing %s/%s from work queue", pod.Namespace, pod.Name)
+		rc.workQueue.Forget(obj)
+	} else if rc.workQueue.NumRequeues(obj) < 5 {
+		log.Errorf("Error: %s", err)
+		log.Infof("Re-adding %s/%s to work queue", pod.Namespace, pod.Name)
+		rc.workQueue.AddRateLimited(obj)
+	} else {
+		log.Infof("Requeue limit reached, removing %s/%s", pod.Namespace, pod.Name)
+		rc.workQueue.Forget(obj)
+		runtime.HandleError(err)
+	}
+
+	return true
+}

--- a/pkg/repair/repaircontroller.go
+++ b/pkg/repair/repaircontroller.go
@@ -130,7 +130,7 @@ func (rc *Controller) processNextItem() bool {
 	if err == nil {
 		log.Debugf("Removing %s/%s from work queue", pod.Namespace, pod.Name)
 		rc.workQueue.Forget(obj)
-	} else if rc.workQueue.NumRequeues(obj) < 5 {
+	} else if rc.workQueue.NumRequeues(obj) < 50 {
 		if strings.Contains(err.Error(), "the object has been modified; please apply your changes to the latest version and try again") {
 			log.Debugf("Object '%s/%s' modified, requeue for retry", pod.Namespace, pod.Name)
 			log.Infof("Re-adding %s/%s to work queue", pod.Namespace, pod.Name)

--- a/pkg/repair/repaircontroller.go
+++ b/pkg/repair/repaircontroller.go
@@ -60,7 +60,7 @@ func NewRepairController(reconciler BrokenPodReconciler) (*Controller, error) {
 					labelSelectors = append(labelSelectors, ls)
 				}
 			}
-			for _, fs := range []string{options.FieldSelector, reconciler.Filters.LabelSelectors} {
+			for _, fs := range []string{options.FieldSelector, reconciler.Filters.FieldSelectors} {
 				if fs != "" {
 					fieldSelectors = append(fieldSelectors, fs)
 				}


### PR DESCRIPTION
There are some performance issues in large clusters with the poll-based repair controller. This switches it to a watch-based controller. Creating the PR for feedback and so we have something to track.

Todo:
[ ] Add more tests
[ ] Possibly swap the controller from a daemonset to a singleton controller, depending on performance
[ ] Fix event generation (does not currently work in watch-based daemon mode)