### PR TITLE
Add ability to wait for config file to appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Helm chart parameters:
 | cniBinDir | | `/opt/cni/bin` | Must be the same as the environment's `--cni-bin-dir` setting (`kubelet` param) |
 | cniConfDir | | `/etc/cni/net.d` | Must be the same as the environment's `--cni-conf-dir` setting (`kubelet` param) |
 | cniConfFileName | | None | Leave unset to auto-find the first file in the `cni-conf-dir` (as `kubelet` does).  Primarily used for testing `install-cni` plugin config.  If set, `install-cni` will inject the plugin config into this file in the `cni-conf-dir` |
+| cniConfWaitSeconds | | 0 | If set, `install-cni` will wait `cniConfWaitSeconds` seconds for the `cniConfFileName` to appear in the `cni-conf-dir` |
 | psp_cluster_role | | | A `ClusterRole` that sets the according use of [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy) for the `ServiceAccount`|
 | chained | `true` or `false` | `true` | Whether to deploy the config file as a plugin chain or as a standalone file in the conf dir. Some k8s flavors (e.g. OpenShift) do not support the chain approach, set to false if this is the case. |
 
@@ -231,6 +232,7 @@ $ gcloud logging read "resource.type=gce_instance AND jsonPayload.SYSLOG_IDENTIF
     - injects the CNI plugin config to the config file pointed to by CNI_CONF_NAME env var
         - example: `CNI_CONF_NAME: 10-calico.conflist`
         - `jq` is used to insert `CNI_NETWORK_CONFIG` into the `plugins` list in `/etc/cni/net.d/${CNI_CONF_NAME}`
+        - wait `CNI_CONF_WAIT_SECONDS` seconds for `CNI_CONF_NAME` to appear (default: 0) 
 
 - `istio-cni`
     - CNI plugin executable copied to `/opt/cni/bin`

--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -114,10 +114,15 @@ spec:
           command: ["/install-cni.sh"]
           env:
 {{- if .Values.cniConfFileName }}
-            # Name of the CNI config file to create.
+            # Name of the CNI config file.
             - name: CNI_CONF_NAME
               value: "{{ .Values.cniConfFileName }}"
 {{- end }}
+{{- if .Values.cniConfWaitSeconds }}
+            # Wait until the CNI config file appears.
+            - name: CNI_CONF_WAIT_SECONDS
+              value: "{{ .Values.cniConfWaitSeconds }}"
+{{- end }
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:

--- a/deployments/kubernetes/install/helm/istio-cni/values.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values.yaml
@@ -14,6 +14,7 @@ logLevel: info
 cniBinDir: /opt/cni/bin
 cniConfDir: /etc/cni/net.d
 cniConfFileName: ""
+cniConfWaitSeconds: ""
 
 excludeNamespaces:
   - istio-system

--- a/deployments/kubernetes/install/scripts/install-cni.sh
+++ b/deployments/kubernetes/install/scripts/install-cni.sh
@@ -131,6 +131,7 @@ CNI_CONF_NAME_OVERRIDE=${CNI_CONF_NAME:-}
 # if dir is empty, default to a filename that is not likely to be lexicographically first in the dir
 CNI_CONF_NAME=${CNI_CONF_NAME:-$(find_cni_conf_file)}
 CNI_CONF_NAME=${CNI_CONF_NAME:-YYY-istio-cni.conflist}
+CNI_CONF_WAIT_SECONDS=${CNI_CONF_WAIT_SECONDS:-0}
 KUBECFG_FILE_NAME=${KUBECFG_FILE_NAME:-ZZZ-istio-cni-kubeconfig}
 CFGCHECK_INTERVAL=${CFGCHECK_INTERVAL:-1}
 
@@ -268,6 +269,12 @@ if [ "${CHAINED_CNI_PLUGIN}" == "true" ]; then
       echo "${CNI_CONF_NAME} doesn't exist, but ${CNI_CONF_NAME}list does; Using it instead."
       CNI_CONF_NAME="${CNI_CONF_NAME}list"
   fi
+
+  while [ ! -e "${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}" ] && [ "${CNI_CONF_WAIT_SECONDS}" -gt 0 ]; do
+    echo "${CNI_CONF_NAME} doesn't exist; Waiting another ${CNI_CONF_WAIT_SECONDS} seconds."
+    CNI_CONF_WAIT_SECONDS="$(($CNI_CONF_WAIT_SECONDS - 1))"
+    sleep 1
+  done
 
   if [ -e "${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}" ]; then
       # This section overwrites an existing plugins list entry to for istio-cni


### PR DESCRIPTION
### Problem
`istio-cni-node` pod may start up earlier than the main CNI provisioner (`aws-node` for example). In this case:
1. `YYY-istio-cni.conflist` will be used incorrectly for some time
2. `install-cni` container will terminate with an error and be restarted as the main CNI config appears

### Solution 1
If user explicitly provides `CNI_CONF_NAME` we could wait until  the latter has appeared. For that purpose another env variable has been introduced: `CNI_CONF_WAIT_SECONDS`

`CNI_CONF_WAIT_SECONDS` is equal 0 by default and doesn't affect default behaviour.

### Solution 2
Instead of falling back to default behaviour we could exit with error if `CNI_CONF_NAME` hasn't appeared in `CNI_CONF_WAIT_SECONDS` interval.

###  Implementation
This PR implements `Solution 1`.

With the following env:
```
      CNI_NET_DIR:            /etc/cni/net.d
      CNI_CONF_NAME:          10-aws.conflist
      CNI_CONF_WAIT_SECONDS:  30
```
you'd see something like:
```
Wrote Istio CNI binaries to /host/opt/cni/bin.
/host/secondary-bin-dir is non-writable, skipping
Using CNI config template from CNI_NETWORK_CONFIG environment variable.
CNI config: {
  "type": "istio-cni",
  "log_level": "info",
  "kubernetes": {
      "kubeconfig": "/etc/cni/net.d/ZZZ-istio-cni-kubeconfig",
      "cni_bin_dir": "/opt/cni/bin",
      "exclude_namespaces": [ "istio-system" ]
  }
}
10-aws.conflist doesn't exist; Waiting another 30 seconds.
10-aws.conflist doesn't exist; Waiting another 29 seconds.
10-aws.conflist doesn't exist; Waiting another 28 seconds.
10-aws.conflist doesn't exist; Waiting another 27 seconds.
10-aws.conflist doesn't exist; Waiting another 26 seconds.
10-aws.conflist doesn't exist; Waiting another 25 seconds.
10-aws.conflist doesn't exist; Waiting another 24 seconds.
10-aws.conflist doesn't exist; Waiting another 23 seconds.
10-aws.conflist doesn't exist; Waiting another 22 seconds.
10-aws.conflist doesn't exist; Waiting another 21 seconds.
10-aws.conflist doesn't exist; Waiting another 20 seconds.
Created CNI config 10-aws.conflist
Done configuring CNI.  Sleep=true
```