### PR TITLE
[release-1.5] Updating CNI helm templates

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -137,7 +137,7 @@ spec:
 {{- if .Values.repair.enabled }}
         # This container repairs broken CNI pods
         - name: repair-cni
-          image: {{ .Values.repair.hub }}/install-cni:{{ .Values.repair.tag }}
+          image: {{ default .Values.hub .Values.repair.hub }}/install-cni:{{ default .Values.tag .Values.repair.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command:
           - /opt/cni/bin/istio-cni-repair

--- a/deployments/kubernetes/install/helm/istio-cni/values.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values.yaml
@@ -33,8 +33,8 @@ chained: "true"
 
 repair:
   enabled: true
-  #hub: gcr.io/istio-testing
-  #tag: latest
+  hub: #gcr.io/istio-testing
+  tag: #latest
 
   initContainerName: "istio-validation"
 

--- a/deployments/kubernetes/install/helm/istio-cni/values.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values.yaml
@@ -33,14 +33,13 @@ chained: "true"
 
 repair:
   enabled: true
-  hub: gcr.io/istio-testing
-  tag: 1.5-dev
+  #hub: gcr.io/istio-testing
+  #tag: latest
 
   initContainerName: "istio-validation"
 
   labelPods: "true"
-  createEvents: "true"
-  deletePods: "false"
+  deletePods: "true"
 
   brokenPodLabelKey: "cni.istio.io/uninitialized"
   brokenPodLabelValue: "true"

--- a/deployments/kubernetes/install/helm/istio-cni/values.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/values.yaml
@@ -33,8 +33,8 @@ chained: "true"
 
 repair:
   enabled: true
-  hub: #gcr.io/istio-testing
-  tag: #latest
+  hub: ""
+  tag: ""
 
   initContainerName: "istio-validation"
 


### PR DESCRIPTION
Updating the CNI helm templates and the istioctl manifests (in a separate istio/istio PR) to make them consistent. Removing the event creation flag, since that functionality is removed.