### PR TITLE
Perform preemption check only when used as a chained plugin

### DIFF
--- a/deployments/kubernetes/install/scripts/install-cni.sh
+++ b/deployments/kubernetes/install/scripts/install-cni.sh
@@ -64,15 +64,17 @@ function find_cni_conf_file() {
 }
 
 function check_install() {
-  cfgfile_nm=$(find_cni_conf_file)
-  if [ "${cfgfile_nm}" != "${CNI_CONF_NAME}" ]; then
-    if [ -n "${CNI_CONF_NAME_OVERRIDE}" ]; then
-       # Install was run with overridden cni config file so don't error out on the preempt check.
-       # Likely the only use for this is testing this script.
-       echo "WARNING: Configured CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
-    else
-       echo "ERROR: CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
-       exit 1
+  if [ "${CHAINED_CNI_PLUGIN}" == "true" ]; then
+    cfgfile_nm=$(find_cni_conf_file)
+    if [ "${cfgfile_nm}" != "${CNI_CONF_NAME}" ]; then
+      if [ -n "${CNI_CONF_NAME_OVERRIDE}" ]; then
+         # Install was run with overridden cni config file so don't error out on the preempt check.
+         # Likely the only use for this is testing this script.
+         echo "WARNING: Configured CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
+      else
+         echo "ERROR: CNI config file \"${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}\" preempted by \"$cfgfile_nm\"."
+         exit 1
+      fi
     fi
   fi
   if [ -e "${MOUNTED_CNI_NET_DIR}/${CNI_CONF_NAME}" ]; then


### PR DESCRIPTION
When Istio CNI is not used as a chained plugin, throwing an
error or logging the preemption warning doesn't make sense.
For example, when using Multus CNI, multiple CNI config
files are in the same dir, but none of them has precedence
over the others, as they are loaded by name. In that case,
logging the warning isn't appropriate.