### PR TITLE
Ignore out/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 # lint
 lintconfig.gen.json
 *.orig
+# Contains the built artifacts
+out/


### PR DESCRIPTION
The new common build files require ignoring the `out/` directory, cf. https://github.com/istio/cni/pull/267.