### PR TITLE
istio-iptables: Replace socket match with conntrack match

### DIFF
--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -422,7 +422,7 @@ if [ -n "${INBOUND_PORTS_INCLUDE}" ]; then
     if [ "${INBOUND_INTERCEPTION_MODE}" = "TPROXY" ]; then
       # If an inbound packet belongs to an established socket, route it to the
       # loopback interface.
-      iptables -t mangle -A ISTIO_INBOUND -p tcp -m socket -j ISTIO_DIVERT || echo "No socket match support"
+      iptables -t mangle -A ISTIO_INBOUND -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT || echo "No conntrack match support"
       # Otherwise, it's a new connection. Redirect it using TPROXY.
       iptables -t mangle -A ISTIO_INBOUND -p tcp -j ISTIO_TPROXY
     else
@@ -432,8 +432,7 @@ if [ -n "${INBOUND_PORTS_INCLUDE}" ]; then
     # User has specified a non-empty list of ports to be redirected to Envoy.
     for port in ${INBOUND_PORTS_INCLUDE}; do
       if [ "${INBOUND_INTERCEPTION_MODE}" = "TPROXY" ]; then
-        iptables -t mangle -A ISTIO_INBOUND -p tcp --dport "${port}" -m socket -j ISTIO_DIVERT || echo "No socket match support"
-        iptables -t mangle -A ISTIO_INBOUND -p tcp --dport "${port}" -m socket -j ISTIO_DIVERT || echo "No socket match support"
+        iptables -t mangle -A ISTIO_INBOUND -p tcp --dport "${port}" -m conntrack --ctstate RELATED,ESTABLISHED -j ISTIO_DIVERT || echo "No conntrack match support"
         iptables -t mangle -A ISTIO_INBOUND -p tcp --dport "${port}" -j ISTIO_TPROXY
       else
         iptables -t nat -A ISTIO_INBOUND -p tcp --dport "${port}" -j ISTIO_IN_REDIRECT


### PR DESCRIPTION
Some kernels, like COS on GKE, are configured without the 'xt_socket'
kernel module that implements the 'socket' match in iptables
rules. Replace the 'socket' match with a 'conntrack' state match that
diverts all established and related packets to the local stack.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>