### PR TITLE
fix inboundport annotation when it is empty

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -227,6 +227,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 					if redirect, redirErr := NewRedirect(ports, annotations); redirErr != nil {
 						log.Errorf("Pod redirect failed due to bad params: %v", redirErr)
 					} else {
+						if redirect.includePorts != "*" {
+							log.Errorf("lambdai: should always redirect to local port but see %v", redirect.includePorts)
+						} else {
+							log.Errorf("lambdai: redirect to local port: %v", redirect.includePorts)
+						}
 						// Get the constructor for the configured type of InterceptRuleMgr
 						interceptMgrCtor := GetInterceptRuleMgrCtor(interceptRuleMgrType)
 						if interceptMgrCtor == nil {

--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -227,11 +227,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 					if redirect, redirErr := NewRedirect(ports, annotations); redirErr != nil {
 						log.Errorf("Pod redirect failed due to bad params: %v", redirErr)
 					} else {
-						if redirect.includePorts != "*" {
-							log.Errorf("lambdai: should always redirect to local port but see %v", redirect.includePorts)
-						} else {
-							log.Errorf("lambdai: redirect to local port: %v", redirect.includePorts)
-						}
+						log.Infof("Redirect local ports: %v", redirect.includePorts)
 						// Get the constructor for the configured type of InterceptRuleMgr
 						interceptMgrCtor := GetInterceptRuleMgrCtor(interceptRuleMgrType)
 						if interceptMgrCtor == nil {

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -198,13 +198,14 @@ func NewRedirect(ports []string, annotations map[string]string) (*Redirect, erro
 		return nil, valErr
 	}
 	isFound, redir.includePorts, valErr = getAnnotationOrDefault("includePorts", annotations)
-	if !isFound || valErr != nil {
+	if valErr != nil {
+		log.Errorf("Annotation value error for redirect ports, using ContainerPorts=\"%s\": %v",
+			redir.includePorts, valErr)
+		return nil, valErr
+	} else if !isFound || redir.includePorts == "*" {
+		redir.includePorts = "*"
+	} else {
 		redir.includePorts = strings.Join(ports, ",")
-		if valErr != nil {
-			log.Errorf("Annotation value error for redirect ports, using ContainerPorts=\"%s\": %v",
-				redir.includePorts, valErr)
-			return nil, valErr
-		}
 	}
 	isFound, redir.excludeIPCidrs, valErr = getAnnotationOrDefault("excludeIPCidrs", annotations)
 	if valErr != nil {


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

The design since istio 1.3 is to capture all inbound traffic by default. 

Fix https://github.com/istio/istio/issues/22482

Also manual tested by apply a deployment with no container port and the expected rule `[2:120] -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006` is hit twice

```
root@host-46:/home/ubuntu# ip netns exec "ebbb5767af2e" iptables-save -c
# Generated by iptables-save v1.6.1 on Fri Mar 27 03:26:23 2020
*nat
:PREROUTING ACCEPT [2450:147000]
:INPUT ACCEPT [2451:147060]
:OUTPUT ACCEPT [46:4064]
:POSTROUTING ACCEPT [47:4124]
:ISTIO_INBOUND - [0:0]
:ISTIO_IN_REDIRECT - [0:0]
:ISTIO_OUTPUT - [0:0]
:ISTIO_REDIRECT - [0:0]
[2451:147060] -A PREROUTING -p tcp -j ISTIO_INBOUND
[6:360] -A OUTPUT -p tcp -j ISTIO_OUTPUT
[0:0] -A ISTIO_INBOUND -p tcp -m tcp --dport 22 -j RETURN
[2450:147000] -A ISTIO_INBOUND -p tcp -m tcp --dport 15020 -j RETURN
[1:60] -A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
[2:120] -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
[0:0] -A ISTIO_OUTPUT -p tcp -m tcp --dport 15020 -j RETURN
[0:0] -A ISTIO_OUTPUT -s 127.0.0.6/32 -o lo -j RETURN
[1:60] -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
[0:0] -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
[5:300] -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
[0:0] -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
[0:0] -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
[0:0] -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
[0:0] -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
[0:0] -A ISTIO_OUTPUT -j ISTIO_REDIRECT
[0:0] -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT
```