### PR TITLE
Add excludeIPRanges configuration

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -55,6 +55,7 @@ type Kubernetes struct {
 	NodeName             string   `json:"node_name"`
 	ExcludeNamespaces    []string `json:"exclude_namespaces"`
 	CniBinDir            string   `json:"cni_bin_dir"`
+	ExcludeIpRanges      string   `json:"exclude_ip_ranges"`
 }
 
 // PluginConf is whatever you expect your configuration json to be. This is whatever
@@ -222,7 +223,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				}
 				if !excludePod {
 					log.Infof("setting up redirect")
-					if redirect, redirErr := NewRedirect(annotations); redirErr != nil {
+					if redirect, redirErr := NewRedirect(annotations, conf); redirErr != nil {
 						log.Errorf("Pod redirect failed due to bad params: %v", redirErr)
 					} else {
 						log.Infof("Redirect local ports: %v", redirect.includePorts)

--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -55,7 +55,7 @@ type Kubernetes struct {
 	NodeName             string   `json:"node_name"`
 	ExcludeNamespaces    []string `json:"exclude_namespaces"`
 	CniBinDir            string   `json:"cni_bin_dir"`
-	ExcludeIpRanges      string   `json:"exclude_ip_ranges"`
+	ExcludeIPRanges      string   `json:"exclude_ip_ranges"`
 }
 
 // PluginConf is whatever you expect your configuration json to be. This is whatever

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -88,7 +88,8 @@ var conf = `{
 		"intercept_type": "mock",
         "node_name": "testNodeName",
         "exclude_namespaces": ["testExcludeNS"],
-        "cni_bin_dir": "/testDirectory"
+        "cni_bin_dir": "/testDirectory",
+        "exclude_ip_ranges": "%s"
     }
     }`
 
@@ -157,6 +158,20 @@ func testCmdInvalidVersion(t *testing.T, f func(args *skel.CmdArgs) error) {
 	if err != nil {
 		if !strings.Contains(err.Error(), "could not convert result to current version") {
 			t.Fatalf("expected substring error 'could not convert result to current version', got: %v", err)
+		}
+	} else {
+		t.Fatalf("expected failed CNI version, got: no error")
+	}
+}
+
+func testCmdInvalidExcludeIpRanges(t *testing.T, f func(args *skel.CmdArgs) error) {
+	cniConf := fmt.Sprintf(conf, invalidVersion, ifname, sandboxDirectory, "10.0.0.1")
+	args := testSetArgs(cniConf)
+
+	err := f(args)
+	if err != nil {
+		if !strings.Contains(err.Error(), "no valid IP addresses") {
+			t.Fatalf("expected substring error 'no valid IP addresses', got: %v", err)
 		}
 	} else {
 		t.Fatalf("expected failed CNI version, got: no error")
@@ -356,6 +371,10 @@ func TestCmdAddInvalidK8sArgsKeyword(t *testing.T) {
 	} else {
 		t.Fatalf("expected a failed response for an invalid K8sArgs setting, got: no error")
 	}
+}
+
+func TestCmdInvalidExcludeIpRanges(t *testing.T) {
+	testCmdInvalidExcludeIpRanges(t, cmdAdd)
 }
 
 func TestCmdAddInvalidVersion(t *testing.T) {

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -174,7 +174,7 @@ func testCmdInvalidExcludeIPRanges(t *testing.T, f func(args *skel.CmdArgs) erro
 			t.Fatalf("expected substring error 'no valid IP addresses', got: %v", err)
 		}
 	} else {
-		t.Fatalf("expected failed CNI version, got: no error")
+		t.Fatalf("expected error for invalid exclude_ip_ranges configuration value, got none")
 	}
 }
 

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -164,7 +164,7 @@ func testCmdInvalidVersion(t *testing.T, f func(args *skel.CmdArgs) error) {
 	}
 }
 
-func testCmdInvalidExcludeIpRanges(t *testing.T, f func(args *skel.CmdArgs) error) {
+func testCmdInvalidExcludeIPRanges(t *testing.T, f func(args *skel.CmdArgs) error) {
 	cniConf := fmt.Sprintf(conf, invalidVersion, ifname, sandboxDirectory, "10.0.0.1")
 	args := testSetArgs(cniConf)
 
@@ -374,7 +374,7 @@ func TestCmdAddInvalidK8sArgsKeyword(t *testing.T) {
 }
 
 func TestCmdInvalidExcludeIpRanges(t *testing.T) {
-	testCmdInvalidExcludeIpRanges(t, cmdAdd)
+	testCmdInvalidExcludeIPRanges(t, cmdAdd)
 }
 
 func TestCmdAddInvalidVersion(t *testing.T) {

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -151,7 +151,7 @@ func testSetArgs(stdinData string) *skel.CmdArgs {
 }
 
 func testCmdInvalidVersion(t *testing.T, f func(args *skel.CmdArgs) error) {
-	cniConf := fmt.Sprintf(conf, invalidVersion, ifname, sandboxDirectory)
+	cniConf := fmt.Sprintf(conf, invalidVersion, ifname, sandboxDirectory, "")
 	args := testSetArgs(cniConf)
 
 	err := f(args)
@@ -179,7 +179,7 @@ func testCmdInvalidExcludeIpRanges(t *testing.T, f func(args *skel.CmdArgs) erro
 }
 
 func testCmdAdd(t *testing.T) {
-	cniConf := fmt.Sprintf(conf, currentVersion, ifname, sandboxDirectory)
+	cniConf := fmt.Sprintf(conf, currentVersion, ifname, sandboxDirectory, "")
 	testCmdAddWithStdinData(t, cniConf)
 }
 
@@ -360,7 +360,7 @@ func TestCmdAddInvalidK8sArgsKeyword(t *testing.T) {
 
 	k8Args = "K8S_POD_NAMESPACE_InvalidKeyword=istio-system"
 
-	cniConf := fmt.Sprintf(conf, currentVersion, ifname, sandboxDirectory)
+	cniConf := fmt.Sprintf(conf, currentVersion, ifname, sandboxDirectory, "")
 	args := testSetArgs(cniConf)
 
 	err := cmdAdd(args)

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -178,7 +178,7 @@ func getAnnotationOrDefault(name string, annotations map[string]string) (isFound
 }
 
 // NewRedirect returns a new Redirect Object constructed from a list of ports and annotations
-func NewRedirect(annotations map[string]string) (*Redirect, error) {
+func NewRedirect(annotations map[string]string, pluginConfiguration *PluginConf) (*Redirect, error) {
 	var isFound bool
 	var valErr error
 
@@ -212,6 +212,14 @@ func NewRedirect(annotations map[string]string) (*Redirect, error) {
 		log.Errorf("Annotation value error for value %s; annotationFound = %t: %v",
 			"excludeIPCidrs", isFound, valErr)
 		return nil, valErr
+	}
+	if !isFound && pluginConfiguration.Kubernetes.ExcludeIpRanges != "" {
+		if valErr := validateCIDRList(pluginConfiguration.Kubernetes.ExcludeIpRanges); valErr != nil {
+			log.Errorf("Plugin configuration value error for value %s; configurationFound = %v, err = %v",
+				"exclude_ip_ranges", pluginConfiguration.Kubernetes.ExcludeIpRanges, valErr)
+			return nil, valErr
+		}
+		redir.excludeIPCidrs = pluginConfiguration.Kubernetes.ExcludeIpRanges
 	}
 	isFound, redir.excludeInboundPorts, valErr = getAnnotationOrDefault("excludeInboundPorts", annotations)
 	if valErr != nil {

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -213,13 +213,13 @@ func NewRedirect(annotations map[string]string, pluginConfiguration *PluginConf)
 			"excludeIPCidrs", isFound, valErr)
 		return nil, valErr
 	}
-	if !isFound && pluginConfiguration.Kubernetes.ExcludeIpRanges != "" {
-		if valErr := validateCIDRList(pluginConfiguration.Kubernetes.ExcludeIpRanges); valErr != nil {
+	if !isFound && pluginConfiguration.Kubernetes.ExcludeIPRanges != "" {
+		if valErr := validateCIDRList(pluginConfiguration.Kubernetes.ExcludeIPRanges); valErr != nil {
 			log.Errorf("Plugin configuration value error for value %s; configurationFound = %v, err = %v",
-				"exclude_ip_ranges", pluginConfiguration.Kubernetes.ExcludeIpRanges, valErr)
+				"exclude_ip_ranges", pluginConfiguration.Kubernetes.ExcludeIPRanges, valErr)
 			return nil, valErr
 		}
-		redir.excludeIPCidrs = pluginConfiguration.Kubernetes.ExcludeIpRanges
+		redir.excludeIPCidrs = pluginConfiguration.Kubernetes.ExcludeIPRanges
 	}
 	isFound, redir.excludeInboundPorts, valErr = getAnnotationOrDefault("excludeInboundPorts", annotations)
 	if valErr != nil {


### PR DESCRIPTION
Issue: istio/istio#19939

This PR supports configuring excludeIPRanges globally for the CNI plugin to bypass proxies.
 
Some Helm chart updates is required to inject the global.proxy.excludeIPRanges. I am gonna send another PR once these changes are incorporated.

includeIPCidrs, includePorts, excludeInboundPorts, excludeOutboundPorts are still missing.