### PR TITLE
Remove namespace from clusterrole and clusterrolebinding

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -198,7 +198,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: istio-cni-repair-role
-  namespace: {{ .Release.Namespace}}
   labels:
     k8s-app: istio-cni-repair
 rules:
@@ -213,7 +212,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istio-cni-repair-rolebinding
-  namespace: {{ .Release.Namespace}}
   labels:
     k8s-app: istio-cni-repair
 subjects:


### PR DESCRIPTION
Cluster roles and cluster role bindings are cluster-wide and not namespace specific. We had a case where this broke installation for us due to some client-go code throwing back a not found error (https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L122) when trying to create these two resources in the cluster. Taking out the namespace (which is set to `kube-system` after the template is instantiated) for the cluster-wide resources got everything to work correctly.