### PR TITLE
Redirect: add 15090 to excludeInboundPorts 

### DIFF
--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -207,7 +207,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 					zap.String("pod", string(k8sArgs.K8S_POD_NAME)),
 					zap.String("Namespace", string(k8sArgs.K8S_POD_NAMESPACE)),
 					zap.Reflect("annotations", annotations))
-				if val, ok := pkg/kube/inject/inject.go[injectAnnotationKey]; ok {
+				if val, ok := annotations[injectAnnotationKey]; ok {
 					log.Infof("Pod %s contains inject annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
 					if injectEnabled, err := strconv.ParseBool(val); err == nil {
 						if !injectEnabled {

--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -207,7 +207,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 					zap.String("pod", string(k8sArgs.K8S_POD_NAME)),
 					zap.String("Namespace", string(k8sArgs.K8S_POD_NAMESPACE)),
 					zap.Reflect("annotations", annotations))
-				if val, ok := annotations[injectAnnotationKey]; ok {
+				if val, ok := pkg/kube/inject/inject.go[injectAnnotationKey]; ok {
 					log.Infof("Pod %s contains inject annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
 					if injectEnabled, err := strconv.ParseBool(val); err == nil {
 						if !injectEnabled {

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -278,6 +278,46 @@ func TestCmdAddTwoContainersWithEmptyInboundPort(t *testing.T) {
 	}
 }
 
+func TestCmdAddTwoContainersWithEmptyExcludeInboundPort(t *testing.T) {
+	defer resetGlobalTestVariables()
+	delete(testAnnotations, includePortsKey)
+	testContainers = []string{"mockContainer", "mockContainer2"}
+	testAnnotations[excludeInboundPortsKey] = ""
+	testCmdAdd(t)
+
+	if !nsenterFuncCalled {
+		t.Fatalf("expected nsenterFunc to be called")
+	}
+	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
+	if !ok {
+		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
+	}
+	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
+	if r.excludeInboundPorts != "15090" {
+		t.Fatalf("expect excludeInboundPorts is \"15090\", actual %v", r.excludeInboundPorts)
+	}
+}
+
+func TestCmdAddTwoContainersWithExplictExcludeInboundPort(t *testing.T) {
+	defer resetGlobalTestVariables()
+	delete(testAnnotations, includePortsKey)
+	testContainers = []string{"mockContainer", "mockContainer2"}
+	testAnnotations[excludeInboundPortsKey] = "3306"
+	testCmdAdd(t)
+
+	if !nsenterFuncCalled {
+		t.Fatalf("expected nsenterFunc to be called")
+	}
+	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
+	if !ok {
+		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
+	}
+	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
+	if r.excludeInboundPorts != "3306,15090" {
+		t.Fatalf("expect excludeInboundPorts is \"3306,15090\", actual %v", r.excludeInboundPorts)
+	}
+}
+
 func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
 	defer resetGlobalTestVariables()
 

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -226,11 +226,11 @@ func NewRedirect(annotations map[string]string) (*Redirect, error) {
 		return nil, valErr
 	}
 	// Add 15090 to sync with non-cni injection template
-	redir.excludeOutboundPorts = strings.TrimSpace(redir.excludeOutboundPorts)
-	if len(redir.excludeOutboundPorts) > 0 && redir.excludeOutboundPorts[len(redir.excludeOutboundPorts)-1] != ',' {
-		redir.excludeOutboundPorts = redir.excludeOutboundPorts + ","
+	redir.excludeInboundPorts = strings.TrimSpace(redir.excludeInboundPorts)
+	if len(redir.excludeInboundPorts) > 0 && redir.excludeInboundPorts[len(redir.excludeInboundPorts)-1] != ',' {
+		redir.excludeInboundPorts = redir.excludeInboundPorts + ","
 	}
-	redir.excludeOutboundPorts = redir.excludeOutboundPorts + "15090"
+	redir.excludeInboundPorts = redir.excludeInboundPorts + "15090"
 	isFound, redir.kubevirtInterfaces, valErr = getAnnotationOrDefault("kubevirtInterfaces", annotations)
 	if valErr != nil {
 		log.Errorf("Annotation value error for value %s; annotationFound = %t: %v",

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -226,11 +226,12 @@ func NewRedirect(annotations map[string]string) (*Redirect, error) {
 		return nil, valErr
 	}
 	// Add 15090 to sync with non-cni injection template
+	// TODO: Revert below once https://github.com/istio/istio/pull/23037 or its follow up is merged.
 	redir.excludeInboundPorts = strings.TrimSpace(redir.excludeInboundPorts)
 	if len(redir.excludeInboundPorts) > 0 && redir.excludeInboundPorts[len(redir.excludeInboundPorts)-1] != ',' {
-		redir.excludeInboundPorts = redir.excludeInboundPorts + ","
+		redir.excludeInboundPorts += ","
 	}
-	redir.excludeInboundPorts = redir.excludeInboundPorts + "15090"
+	redir.excludeInboundPorts += "15090"
 	isFound, redir.kubevirtInterfaces, valErr = getAnnotationOrDefault("kubevirtInterfaces", annotations)
 	if valErr != nil {
 		log.Errorf("Annotation value error for value %s; annotationFound = %t: %v",

--- a/cmd/istio-cni/redirect.go
+++ b/cmd/istio-cni/redirect.go
@@ -225,6 +225,12 @@ func NewRedirect(annotations map[string]string) (*Redirect, error) {
 			"excludeOutboundPorts", isFound, valErr)
 		return nil, valErr
 	}
+	// Add 15090 to sync with non-cni injection template
+	redir.excludeOutboundPorts = strings.TrimSpace(redir.excludeOutboundPorts)
+	if len(redir.excludeOutboundPorts) > 0 && redir.excludeOutboundPorts[len(redir.excludeOutboundPorts)-1] != ',' {
+		redir.excludeOutboundPorts = redir.excludeOutboundPorts + ","
+	}
+	redir.excludeOutboundPorts = redir.excludeOutboundPorts + "15090"
 	isFound, redir.kubevirtInterfaces, valErr = getAnnotationOrDefault("kubevirtInterfaces", annotations)
 	if valErr != nil {
 		log.Errorf("Annotation value error for value %s; annotationFound = %t: %v",


### PR DESCRIPTION
As workaround of #23038 
Simulate what non-cni template injector does on port 15090.

excludeInboundPorts is read only if includeInboundPorts is '*' so we can blindly add 15090 regardless if excludeInboundPorts is used

Should revert this PR when `podRedirectAnnot` is propagated to webhook along with https://github.com/istio/istio/pull/23037