### PR TITLE
[release-1.4] Backport required missing fields to cni helm charts

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -44,6 +44,8 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
         {
+          "cniVersion": "0.3.1",
+          "name": "istio-cni",
           "type": "istio-cni",
           "log_level": {{ quote .Values.logLevel }},
           "kubernetes": {


### PR DESCRIPTION
Fix for installer was done at https://github.com/istio/installer/pull/669/files
but helm charts were not modified for release 1.4.