### PR TITLE
[release-1.5] Add missing required CNI fields to helm charts for Openshift 4.3.5

### DIFF
--- a/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
+++ b/deployments/kubernetes/install/helm/istio-cni/templates/istio-cni.yaml
@@ -44,6 +44,8 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
         {
+          "cniVersion:": "0.3.1",
+          "name:": "istio-cni",
           "type": "istio-cni",
           "log_level": {{ quote .Values.logLevel }},
           "kubernetes": {


### PR DESCRIPTION
Similar to https://github.com/istio/installer/pull/669/files but for release 1.5