### PR TITLE
Fixing cos_containerd mounting repair binary with noexec

### DIFF
--- a/deployments/kubernetes/Dockerfile.install-cni
+++ b/deployments/kubernetes/Dockerfile.install-cni
@@ -16,6 +16,5 @@ COPY istio-cni.conf.default /istio-cni.conf.tmp
 COPY istio-cni-repair /opt/cni/bin/
 
 ENV PATH=$PATH:/opt/cni/bin
-VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/install-cni.sh"]


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/23643.

The `VOLUME` declaration causes all of `/opt` in the docker container to be mounted with `noexec`, which prevents the CNI repair binary from being executed.