### PR TITLE
Reworking ipv6 detection logic

### DIFF
--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -264,12 +264,14 @@ if [ -z "${PROXY_GID}" ]; then
 PROXY_GID=${PROXY_UID}
 fi
 
-POD_IP=$(hostname --ip-address)
-# Check if pod's ip is ipv4 or ipv6, in case of ipv6 set variable
+# Check if any of the pod's ip addresses are ipv6. If so, set variable
 # to program ip6tables
-if isIPv6 "$POD_IP"; then
-  ENABLE_INBOUND_IPV6=$POD_IP
-fi
+hostname --all-ip-addresses | while read -d' ' POD_IP; do
+  if isIPv6 "$POD_IP"; then
+    ENABLE_INBOUND_IPV6=$POD_IP
+    break
+  fi
+done
 
 #
 # Since OUTBOUND_IP_RANGES_EXCLUDE could carry ipv4 and ipv6 ranges

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -266,10 +266,12 @@ fi
 
 # Check if any of the pod's ip addresses are ipv6. If so, set variable
 # to program ip6tables
-hostname --all-ip-addresses | while read -d' ' POD_IP; do
+ip -brief -oneline addr | awk '{print $3}' | sed 's|/.*||g' | while read POD_IP; do
   if isIPv6 "$POD_IP"; then
+    echo "Found ipv6 pod IP: ${POD_IP}"
     ENABLE_INBOUND_IPV6=$POD_IP
-    break
+  else
+    echo "Found ipv4 pod IP: ${POD_IP}"
   fi
 done
 

--- a/tools/packaging/common/istio-iptables.sh
+++ b/tools/packaging/common/istio-iptables.sh
@@ -271,14 +271,14 @@ fi
 # The odd structure of this loop is to prevent the while loop from
 # executing in a subshell, which prevents ENABLE_INBOUND_IPV6 from
 # being set in the main script.
-while read POD_IP; do 
+while read -r POD_IP; do 
   if isIPv6 "$POD_IP"; then
     echo "Found ipv6 pod IP: ${POD_IP}"
     ENABLE_INBOUND_IPV6="${POD_IP}"
   else
     echo "Found ipv4 pod IP: ${POD_IP}"
   fi
-done <<<$(ip -brief -oneline addr | awk '{print $3}' | sed 's|/.*||g')
+done <<< "$(ip -brief -oneline addr | awk '{print $3}' | sed 's|/.*||g')"
 
 #
 # Since OUTBOUND_IP_RANGES_EXCLUDE could carry ipv4 and ipv6 ranges


### PR DESCRIPTION
From `man hostname`:
```
-i, --ip-address
Display the IP address(es) of the host. Note that this works only if the host name can be resolved. Avoid using this option; use hostname --all-ip-addresses instead.
```
I've reworked the logic to use `--all-ip-addresses`, which shouldn't require a DNS query. Instead, we now loop across all IP addresses for the pod, and if we encounter one that is an ipv6 address, we enable ipv6 inbound rules.

This should fix https://github.com/istio/istio/issues/23770