### PR TITLE
Fixes BusyBox nsenter from parsing iptables script args

### DIFF
--- a/cmd/istio-cni/iptables.go
+++ b/cmd/istio-cni/iptables.go
@@ -43,6 +43,7 @@ func (ipt *iptables) Program(netns string, rdrct *Redirect) error {
 	nsSetupExecutable := fmt.Sprintf("%s/%s", nsSetupBinDir, nsSetupProg)
 	nsenterArgs := []string{
 		netnsArg,
+		"--", // separate nsenter args from the rest with `--`, needed for hosts using BusyBox binaries
 		nsSetupExecutable,
 		"-p", rdrct.targetPort,
 		"-u", rdrct.noRedirectUID,


### PR DESCRIPTION
Prevents BusyBox's build of `nsenter` from incorrectly parsing `istio-iptables.sh` arguments as its own. Discovered when using the Kubernetes distribution "k3s" (https://github.com/k3s-io/k3s/issues/1434). A similar fix was used for [Linkerd](https://github.com/linkerd/linkerd2-proxy-init/pull/26).